### PR TITLE
chore: prepare v2.5.1 release

### DIFF
--- a/docs/releases/v2.5.1.md
+++ b/docs/releases/v2.5.1.md
@@ -1,0 +1,26 @@
+# GTD Space {{tag}}
+
+## Highlights
+
+- Fixed the habit completion flow so saved check-offs now survive restart and show up correctly in the dashboard and calendar.
+- Hardened the release pipeline with a dedicated release-path E2E suite and automatic Rust lockfile version sync during version bumps.
+
+## Notable Changes
+
+- Preserved backend habit status and history rewrites when an open habit tab still has local edits, so a later save no longer wipes out the recorded completion.
+- Refreshed dashboard habit data when habit files save, change, or reset, and added regression coverage for the dashboard subscription path.
+- Added `test:release:e2e` to the release gates and updated the version bump script so `src-tauri/Cargo.lock` and `src-tauri/mcp-server/Cargo.lock` track the shipped app version.
+
+## Installation
+
+Download the installer or package that matches your platform:
+
+- Windows: `.msi` installer or `.exe` (NSIS) installer
+- macOS Intel: `.dmg` for Intel Macs
+- macOS Apple Silicon: `.dmg` for Apple Silicon Macs
+- Linux: `.AppImage` (universal) or `.deb` (Debian/Ubuntu)
+
+## Notes
+
+- `{{tag}}` is the recommended patch upgrade on top of `v2.5.0`.
+- No workspace migration is required for this release.

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -18,6 +18,30 @@ function writeFile(filePath, content) {
   fs.writeFileSync(filePath, content, 'utf8');
 }
 
+function syncCargoLockVersion(lockPath, packageName, newVersion) {
+  if (!fs.existsSync(lockPath)) {
+    return false;
+  }
+
+  const lockContent = readFile(lockPath);
+  const packageBlockRegex = new RegExp(
+    `(\\[\\[package\\]\\]\\nname = "${packageName}"\\nversion = ")[^"]+(")`,
+    'm'
+  );
+
+  if (!packageBlockRegex.test(lockContent)) {
+    return false;
+  }
+
+  const updatedLockContent = lockContent.replace(packageBlockRegex, `$1${newVersion}$2`);
+  if (updatedLockContent === lockContent) {
+    return false;
+  }
+
+  writeFile(lockPath, updatedLockContent);
+  return true;
+}
+
 export function bumpVersion(currentVersion, type) {
   const sanitize = (v) => String(v).trim().replace(/^v/i, '');
   const base = (v) => sanitize(v).replace(/[+-].*$/, ''); // strip prerelease/build for bump math
@@ -114,6 +138,24 @@ function main() {
   writeFile(tauriConfPath, JSON.stringify(tauriConf, null, 2) + '\n');
   console.log(`✓ Updated src-tauri/tauri.conf.json to version ${newVersion}`);
 
+  const syncedRootCargoLock = syncCargoLockVersion(
+    path.join(repoRoot, 'src-tauri', 'Cargo.lock'),
+    'gtdspace',
+    newVersion
+  );
+  if (syncedRootCargoLock) {
+    console.log(`✓ Updated src-tauri/Cargo.lock to version ${newVersion}`);
+  }
+
+  const syncedMcpCargoLock = syncCargoLockVersion(
+    path.join(repoRoot, 'src-tauri', 'mcp-server', 'Cargo.lock'),
+    'gtdspace',
+    newVersion
+  );
+  if (syncedMcpCargoLock) {
+    console.log(`✓ Updated src-tauri/mcp-server/Cargo.lock to version ${newVersion}`);
+  }
+
   const commitMessage = `chore: bump version to v${newVersion}`;
   const tagName = `v${newVersion}`;
 
@@ -132,6 +174,8 @@ function main() {
       'package.json',
       'src-tauri/Cargo.toml',
       'src-tauri/tauri.conf.json',
+      'src-tauri/Cargo.lock',
+      'src-tauri/mcp-server/Cargo.lock',
     ];
 
     if (fs.existsSync(path.join(repoRoot, 'package-lock.json'))) {
@@ -180,7 +224,7 @@ function main() {
   } catch (error) {
     console.error('Failed to create git commit/tag:', error.message);
     console.log('\nYou can manually commit and tag the changes:');
-    console.log(`  git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/tauri.conf.json`);
+    console.log(`  git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/tauri.conf.json src-tauri/Cargo.lock src-tauri/mcp-server/Cargo.lock`);
     console.log(`  git commit -m "${commitMessage}"`);
     console.log(`  git tag -a ${tagName} -m "Release ${tagName}"`);
   }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/mcp-server/Cargo.lock
+++ b/src-tauri/mcp-server/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary
- add the checked-in release notes for `v2.5.1`
- teach the version bump script to keep Rust lockfiles aligned with the shipped app version
- sync the existing Rust lockfiles so the patch release starts from a clean baseline

## Verification
- node --check scripts/bump-version.js
- npm run release:notes -- v2.5.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v2.5.1 Release Notes

* **Bug Fixes**
  * Fixed habit completion persistence across app restarts
  * Improved preservation of habit data when concurrent edits occur
  * Enhanced dashboard refresh behavior on file changes

* **Tests**
  * Added regression coverage for dashboard functionality

* **Chores**
  * Strengthened release pipeline with dedicated testing suite
  * Updated installation documentation for multiple platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->