### PR TITLE
[codex] release: bump version to v2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtdspace",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gtdspace",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "dependencies": {
         "@blocknote/code-block": "~0.37.0",
         "@blocknote/core": "~0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gtdspace",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "GTD-first productivity system with integrated markdown editing",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtdspace"
-version = "2.5.0"
+version = "2.5.1"
 description = "GTD-first productivity system with integrated markdown editing"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/mcp-server/Cargo.lock
+++ b/src-tauri/mcp-server/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "GTD Space",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "identifier": "com.gtdspace.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump the app and package metadata from `2.5.0` to `2.5.1`
- sync the Rust lockfiles so the shipped version matches the tagged release
- land the exact commit that `v2.5.1` points to on `main`

## Why
The protected branch rule rejected the direct `main` push during the release script. The `v2.5.1` tag and release workflows were already created from the version bump commit, so this PR brings that same commit onto `main` through the required PR path.

## Validation
- `npm run test:run`
- `npm run test:release:e2e`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- active GitHub release workflows for `v2.5.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.5.1 (patch release)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->