### PR TITLE
[codex] Refactor sidebar controller

### DIFF
--- a/src/components/gtd/sidebar/utils.tsx
+++ b/src/components/gtd/sidebar/utils.tsx
@@ -4,6 +4,11 @@ import {
   CircleDot,
   XCircle,
 } from 'lucide-react';
+import {
+  buildSectionPath,
+  buildSectionPathCandidates,
+  normalizeSidebarPath,
+} from '@/hooks/sidebar/path-classification';
 import { normalizeStatus } from '@/utils/gtd-status';
 import { norm } from '@/utils/path';
 import { CALENDAR_FILE_ID } from '@/utils/special-files';
@@ -21,9 +26,7 @@ export const getFolderName = (fullPath: string): string => {
   return segments[segments.length - 1] ?? '';
 };
 
-export const normalizePath = (path?: string | null): string | null => {
-  return norm(path) ?? null;
-};
+export const normalizePath = normalizeSidebarPath;
 
 export const isPathDescendant = (
   parent?: string | null,
@@ -124,24 +127,7 @@ export const getStatusIcon = (statusInput: string) => {
 
 export const getDisplayName = (name: string): string => name.replace(/\.(?:md|markdown)$/i, '');
 
-export const buildSectionPath = (
-  rootPath: string | null | undefined,
-  sectionPath: string
-): string => {
-  const base = (rootPath ?? '').replace(/[\\/]+$/, '');
-  if (!base) return norm(sectionPath) ?? sectionPath;
-  const separator = base.includes('\\') ? '\\' : '/';
-  return norm(`${base}${separator}${sectionPath}`) ?? `${base}${separator}${sectionPath}`;
-};
-
-export const buildSectionPathCandidates = (
-  rootPath: string | null | undefined,
-  section: Pick<GTDSection, 'path' | 'aliases'>
-): string[] => {
-  const candidates = [section.path, ...(section.aliases ?? [])]
-    .map((candidate) => buildSectionPath(rootPath, candidate));
-  return [...new Set(candidates)];
-};
+export { buildSectionPath, buildSectionPathCandidates };
 
 export const createCalendarFile = (): MarkdownFile => ({
   id: CALENDAR_FILE_ID,

--- a/src/hooks/sidebar/path-classification.ts
+++ b/src/hooks/sidebar/path-classification.ts
@@ -1,0 +1,275 @@
+import type { GTDSection } from '@/components/gtd/sidebar/types';
+import { GTD_SECTIONS } from '@/components/gtd/sidebar/constants';
+import type { SidebarPathMatch } from '@/hooks/sidebar/types';
+import { norm, isUnder } from '@/utils/path';
+
+const MARKDOWN_FILE_PATTERN = /\.(md|markdown)$/i;
+const README_FILE_PATTERN = /\/README\.(md|markdown)$/i;
+
+function getSidebarSections(): GTDSection[] {
+  return GTD_SECTIONS.filter(
+    (section) => section.id !== 'calendar' && section.id !== 'projects'
+  );
+}
+
+export function normalizeSidebarPath(path?: string | null): string | null {
+  return norm(path) ?? null;
+}
+
+export const normalizePath = normalizeSidebarPath;
+
+export function buildSectionPath(
+  rootPath: string | null | undefined,
+  sectionPath: string
+): string {
+  const base = (rootPath ?? '').replace(/[\\/]+$/, '');
+  if (!base) return normalizeSidebarPath(sectionPath) ?? sectionPath;
+  const separator = base.includes('\\') ? '\\' : '/';
+  return normalizeSidebarPath(`${base}${separator}${sectionPath}`) ?? `${base}${separator}${sectionPath}`;
+}
+
+export function buildSectionPathCandidates(
+  rootPath: string | null | undefined,
+  section: Pick<GTDSection, 'path' | 'aliases'>
+): string[] {
+  const candidates = [section.path, ...(section.aliases ?? [])]
+    .map((candidate) => buildSectionPath(rootPath, candidate));
+  return [...new Set(candidates)];
+}
+
+export function getSectionPathVariants(
+  sectionId: string,
+  rootPath?: string | null
+): string[] {
+  const section = GTD_SECTIONS.find((candidate) => candidate.id === sectionId);
+  if (!section) {
+    return [];
+  }
+
+  const names = Array.from(new Set([section.path, ...(section.aliases ?? [])]));
+  return names.map((name) => {
+    if (rootPath) {
+      return buildSectionPath(rootPath, name);
+    }
+    return normalizeSidebarPath(`/${name}/`) ?? `/${name}/`;
+  });
+}
+
+export function getCombinedSectionPathVariants(
+  sectionIds: readonly string[],
+  rootPath?: string | null
+): string[] {
+  return sectionIds.flatMap((sectionId) => getSectionPathVariants(sectionId, rootPath));
+}
+
+export function isReadmePath(path?: string | null): boolean {
+  const normalizedPath = normalizeSidebarPath(path);
+  return normalizedPath ? README_FILE_PATTERN.test(normalizedPath) : false;
+}
+
+export function extractParentFolder(path?: string | null): string | null {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath) return null;
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+  if (lastSlashIndex <= 0) {
+    return null;
+  }
+  return normalizedPath.slice(0, lastSlashIndex);
+}
+
+export function extractProjectPathFromReadme(path?: string | null): string | null {
+  if (!isReadmePath(path)) {
+    return null;
+  }
+  return extractParentFolder(path);
+}
+
+function getProjectSectionRoot(rootPath?: string | null): string | null {
+  const projectsSection = GTD_SECTIONS.find((section) => section.id === 'projects');
+  if (!projectsSection) {
+    return rootPath ? buildSectionPath(rootPath, 'Projects') : '/Projects';
+  }
+  return buildSectionPath(rootPath, projectsSection.path);
+}
+
+function extractProjectPathFromAction(
+  path?: string | null,
+  rootPath?: string | null
+): string | null {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath) {
+    return null;
+  }
+
+  if (rootPath) {
+    const projectRoot = getProjectSectionRoot(rootPath);
+    if (!projectRoot || !isUnder(normalizedPath, projectRoot)) {
+      return null;
+    }
+    const relative = normalizedPath.slice(projectRoot.length).replace(/^\/+/, '');
+    const firstSegment = relative.split('/')[0];
+    if (!firstSegment) {
+      return null;
+    }
+    return normalizeSidebarPath(`${projectRoot}/${firstSegment}`) ?? `${projectRoot}/${firstSegment}`;
+  }
+
+  const match = normalizedPath.match(/^(.*\/Projects\/[^/]+)\//i);
+  return match?.[1] ?? null;
+}
+
+export function inferSectionContextFromPath(
+  normalizedPath: string
+): { root: string | null; section: GTDSection } | null {
+  for (const section of getSidebarSections()) {
+    const candidateNames = Array.from(new Set([section.path, ...(section.aliases ?? [])]));
+    for (const candidateName of candidateNames) {
+      const marker = `/${candidateName}`;
+      const markerIndex = normalizedPath.lastIndexOf(marker);
+      if (markerIndex < 0) {
+        continue;
+      }
+
+      const nextChar = normalizedPath[markerIndex + marker.length];
+      if (nextChar !== undefined && nextChar !== '/') {
+        continue;
+      }
+
+      const inferredRoot = normalizedPath.slice(0, markerIndex) || null;
+      return { root: inferredRoot, section };
+    }
+  }
+
+  return null;
+}
+
+function resolveSectionPathMatch(
+  normalizedPath: string,
+  rootPath?: string | null
+): { section: GTDSection; sectionPath: string } | null {
+  if (rootPath) {
+    for (const section of getSidebarSections()) {
+      const candidatePaths = buildSectionPathCandidates(rootPath, section);
+      for (const candidatePath of candidatePaths) {
+        if (isUnder(normalizedPath, candidatePath)) {
+          const sectionPath = extractParentFolder(normalizedPath);
+          if (!sectionPath) {
+            return null;
+          }
+          return { section, sectionPath };
+        }
+      }
+    }
+  }
+
+  const inferred = inferSectionContextFromPath(normalizedPath);
+  if (!inferred) {
+    return null;
+  }
+
+  const sectionPath = extractParentFolder(normalizedPath);
+  if (!sectionPath) {
+    return null;
+  }
+
+  return { section: inferred.section, sectionPath };
+}
+
+export function isProjectReadmePath(
+  path?: string | null,
+  rootPath?: string | null
+): boolean {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath || !isReadmePath(normalizedPath)) {
+    return false;
+  }
+
+  if (rootPath) {
+    const projectRoot = getProjectSectionRoot(rootPath);
+    return Boolean(projectRoot && isUnder(normalizedPath, projectRoot));
+  }
+
+  return /\/Projects\/.+\/README\.(md|markdown)$/i.test(normalizedPath);
+}
+
+export function isProjectActionPath(
+  path?: string | null,
+  rootPath?: string | null
+): boolean {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath || !MARKDOWN_FILE_PATTERN.test(normalizedPath) || isReadmePath(normalizedPath)) {
+    return false;
+  }
+
+  if (rootPath) {
+    const projectRoot = getProjectSectionRoot(rootPath);
+    return Boolean(projectRoot && isUnder(normalizedPath, projectRoot));
+  }
+
+  return /\/Projects\/.+\.(md|markdown)$/i.test(normalizedPath);
+}
+
+export function isSectionFilePath(
+  path?: string | null,
+  rootPath?: string | null
+): boolean {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath || !MARKDOWN_FILE_PATTERN.test(normalizedPath)) {
+    return false;
+  }
+
+  return resolveSectionPathMatch(normalizedPath, rootPath) !== null;
+}
+
+export function matchesSectionPathVariants(
+  path?: string | null,
+  sectionIds: readonly string[] = [],
+  rootPath?: string | null
+): boolean {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath) {
+    return false;
+  }
+
+  return getCombinedSectionPathVariants(sectionIds, rootPath).some((candidate) =>
+    isUnder(normalizedPath, candidate)
+  );
+}
+
+export function classifySidebarPath(
+  path?: string | null,
+  rootPath?: string | null
+): SidebarPathMatch {
+  const normalizedPath = normalizeSidebarPath(path);
+  if (!normalizedPath) {
+    return { kind: 'other', normalizedPath: '' };
+  }
+
+  if (isProjectReadmePath(normalizedPath, rootPath)) {
+    return {
+      kind: 'project-readme',
+      normalizedPath,
+      projectPath: extractProjectPathFromReadme(normalizedPath) ?? undefined,
+    };
+  }
+
+  if (isProjectActionPath(normalizedPath, rootPath)) {
+    return {
+      kind: 'project-action',
+      normalizedPath,
+      projectPath: extractProjectPathFromAction(normalizedPath, rootPath) ?? undefined,
+    };
+  }
+
+  const sectionMatch = resolveSectionPathMatch(normalizedPath, rootPath);
+  if (sectionMatch) {
+    return {
+      kind: 'section-file',
+      normalizedPath,
+      sectionId: sectionMatch.section.id,
+      sectionPath: sectionMatch.sectionPath,
+    };
+  }
+
+  return { kind: 'other', normalizedPath };
+}

--- a/src/hooks/sidebar/types.ts
+++ b/src/hooks/sidebar/types.ts
@@ -1,0 +1,147 @@
+import type React from 'react';
+import type { UseErrorHandlerReturn } from '@/hooks/useErrorHandler';
+import type {
+  PageDialogDirectory,
+  SidebarActionMetadata,
+  SidebarDeleteItem,
+  SidebarProjectMetadata,
+  SidebarSectionFileMetadata,
+} from '@/components/gtd/sidebar/types';
+import type { GTDProject, MarkdownFile } from '@/types';
+
+export type SidebarUiState = {
+  showProjectDialog: boolean;
+  setShowProjectDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  showActionDialog: boolean;
+  setShowActionDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedProject: GTDProject | null;
+  setSelectedProject: React.Dispatch<React.SetStateAction<GTDProject | null>>;
+  expandedSections: string[];
+  setExpandedSections: React.Dispatch<React.SetStateAction<string[]>>;
+  expandedProjects: string[];
+  setExpandedProjects: React.Dispatch<React.SetStateAction<string[]>>;
+  completedProjectsExpanded: boolean;
+  setCompletedProjectsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+  cancelledProjectsExpanded: boolean;
+  setCancelledProjectsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+  expandedCompletedActions: Set<string>;
+  setExpandedCompletedActions: React.Dispatch<React.SetStateAction<Set<string>>>;
+  searchQuery: string;
+  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  showSearch: boolean;
+  setShowSearch: React.Dispatch<React.SetStateAction<boolean>>;
+  showPageDialog: boolean;
+  setShowPageDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  pageDialogDirectory: PageDialogDirectory | null;
+  setPageDialogDirectory: React.Dispatch<React.SetStateAction<PageDialogDirectory | null>>;
+  showHabitDialog: boolean;
+  setShowHabitDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  deleteItem: SidebarDeleteItem | null;
+  setDeleteItem: React.Dispatch<React.SetStateAction<SidebarDeleteItem | null>>;
+  toggleSection: (sectionId: string) => void;
+  toggleCompletedActions: (projectPath: string) => void;
+};
+
+export type SidebarOverlayState = {
+  projectMetadata: Record<string, SidebarProjectMetadata>;
+  actionMetadata: Record<string, SidebarActionMetadata>;
+  sectionFileMetadata: Record<string, SidebarSectionFileMetadata>;
+  actionStatuses: Record<string, string>;
+  setProjectMetadata: React.Dispatch<
+    React.SetStateAction<Record<string, SidebarProjectMetadata>>
+  >;
+  setActionMetadata: React.Dispatch<
+    React.SetStateAction<Record<string, SidebarActionMetadata>>
+  >;
+  setSectionFileMetadata: React.Dispatch<
+    React.SetStateAction<Record<string, SidebarSectionFileMetadata>>
+  >;
+  setActionStatuses: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  updateProjectOverlay: (
+    projectPath: string,
+    patch: Partial<SidebarProjectMetadata>
+  ) => void;
+  updateActionOverlay: (
+    actionPath: string,
+    patch: Partial<SidebarActionMetadata>
+  ) => void;
+  updateSectionFileOverlay: (
+    filePath: string,
+    patch: Partial<SidebarSectionFileMetadata>
+  ) => void;
+  removeProjectOverlay: (projectPath: string) => void;
+  removeActionOverlay: (filePath: string) => void;
+  removeSectionFileOverlay: (filePath: string) => void;
+  resetOverlays: () => void;
+};
+
+export type SidebarDataState = {
+  sectionFiles: Record<string, MarkdownFile[]>;
+  setSectionFiles: React.Dispatch<React.SetStateAction<Record<string, MarkdownFile[]>>>;
+  sectionFilesRef: React.MutableRefObject<Record<string, MarkdownFile[]>>;
+  projectActions: Record<string, MarkdownFile[]>;
+  setProjectActions: React.Dispatch<React.SetStateAction<Record<string, MarkdownFile[]>>>;
+  projectActionsRef: React.MutableRefObject<Record<string, MarkdownFile[]>>;
+  projectLoading: Record<string, boolean>;
+  setProjectLoading: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  projectLoadingRef: React.MutableRefObject<Record<string, boolean>>;
+  loadingSections: Set<string>;
+  setLoadingSections: React.Dispatch<React.SetStateAction<Set<string>>>;
+  loadingSectionsRef: React.MutableRefObject<Set<string>>;
+  loadedSections: Set<string>;
+  setLoadedSections: React.Dispatch<React.SetStateAction<Set<string>>>;
+  pendingProjects: GTDProject[];
+  setPendingProjects: React.Dispatch<React.SetStateAction<GTDProject[]>>;
+  lastRootRef: React.MutableRefObject<string | null>;
+  preloadedRef: React.MutableRefObject<boolean>;
+  workspaceGenerationRef: React.MutableRefObject<number>;
+  resetDataState: () => void;
+};
+
+export type SidebarPathKind =
+  | 'project-readme'
+  | 'project-action'
+  | 'section-file'
+  | 'other';
+
+export type SidebarPathMatch = {
+  kind: SidebarPathKind;
+  normalizedPath: string;
+  projectPath?: string;
+  sectionId?: string;
+  sectionPath?: string;
+};
+
+export type SidebarWithErrorHandling = UseErrorHandlerReturn['withErrorHandling'];
+
+export type SidebarLoaderDeps = {
+  rootPath: string | null;
+  withErrorHandling: SidebarWithErrorHandling;
+  overlays: Pick<
+    SidebarOverlayState,
+    'setActionMetadata' | 'setActionStatuses'
+  >;
+};
+
+export type SidebarEventBridgeDeps = {
+  rootPath: string | null;
+  withErrorHandling: SidebarWithErrorHandling;
+  loadProjects: (path: string) => Promise<GTDProject[]>;
+  loadProjectActions: (projectPath: string) => Promise<void>;
+  loadSectionFiles: (sectionPath: string, force?: boolean) => Promise<MarkdownFile[]>;
+  overlays: Pick<
+    SidebarOverlayState,
+    | 'setActionStatuses'
+    | 'updateProjectOverlay'
+    | 'updateActionOverlay'
+    | 'updateSectionFileOverlay'
+    | 'removeProjectOverlay'
+    | 'removeActionOverlay'
+    | 'removeSectionFileOverlay'
+  >;
+  ui: Pick<SidebarUiState, 'setExpandedProjects'>;
+  data: Pick<
+    SidebarDataState,
+    'setPendingProjects' | 'setProjectActions'
+  >;
+};

--- a/src/hooks/sidebar/useSidebarDataLoaders.ts
+++ b/src/hooks/sidebar/useSidebarDataLoaders.ts
@@ -1,0 +1,518 @@
+import React from 'react';
+import { flushSync } from 'react-dom';
+import { safeInvoke } from '@/utils/safe-invoke';
+import { readFileText } from '@/hooks/useFileManager';
+import {
+  buildHorizonReadmeMarkdown,
+  syncHorizonReadmeContent,
+} from '@/utils/horizon-readme-utils';
+import { parseActionMarkdown } from '@/utils/gtd-action-markdown';
+import { GTD_SECTIONS, HORIZON_FOLDER_TO_TYPE } from '@/components/gtd/sidebar/constants';
+import { getFolderName, sortMarkdownFiles } from '@/components/gtd/sidebar/utils';
+import type { SidebarLoaderDeps, SidebarDataState } from '@/hooks/sidebar/types';
+import {
+  buildSectionPathCandidates,
+  inferSectionContextFromPath,
+  normalizeSidebarPath,
+} from '@/hooks/sidebar/path-classification';
+import type { GTDProject, MarkdownFile } from '@/types';
+import { norm, isUnder } from '@/utils/path';
+
+type UseSidebarDataLoadersResult = SidebarDataState & {
+  resolveReadmeFile: (folderPath: string) => Promise<MarkdownFile>;
+  resolveSectionLoadPaths: (
+    sectionIds: readonly string[],
+    root: string
+  ) => Promise<string[]>;
+  loadSectionFiles: (sectionPath: string, force?: boolean) => Promise<MarkdownFile[]>;
+  loadProjectActions: (projectPath: string) => Promise<void>;
+};
+
+export function useSidebarDataLoaders({
+  rootPath,
+  withErrorHandling,
+  overlays,
+}: SidebarLoaderDeps): UseSidebarDataLoadersResult {
+  const [projectActions, setProjectActions] = React.useState<
+    Record<string, MarkdownFile[]>
+  >({});
+  const [projectLoading, setProjectLoading] = React.useState<Record<string, boolean>>(
+    {}
+  );
+  const [sectionFiles, setSectionFiles] = React.useState<
+    Record<string, MarkdownFile[]>
+  >({});
+  const [loadingSections, setLoadingSections] = React.useState<Set<string>>(
+    new Set()
+  );
+  const [loadedSections, setLoadedSections] = React.useState<Set<string>>(
+    new Set()
+  );
+  const [pendingProjects, setPendingProjects] = React.useState<GTDProject[]>([]);
+
+  const sectionFilesRef = React.useRef<Record<string, MarkdownFile[]>>({});
+  const projectActionsRef = React.useRef<Record<string, MarkdownFile[]>>({});
+  const projectLoadingRef = React.useRef<Record<string, boolean>>({});
+  const loadingSectionsRef = React.useRef<Set<string>>(new Set());
+  const lastRootRef = React.useRef<string | null>(null);
+  const preloadedRef = React.useRef(false);
+  const workspaceGenerationRef = React.useRef(0);
+
+  React.useEffect(() => {
+    sectionFilesRef.current = sectionFiles;
+  }, [sectionFiles]);
+
+  React.useEffect(() => {
+    projectActionsRef.current = projectActions;
+  }, [projectActions]);
+
+  React.useEffect(() => {
+    projectLoadingRef.current = projectLoading;
+  }, [projectLoading]);
+
+  const resetDataState = React.useCallback(() => {
+    setLoadedSections(new Set());
+    setSectionFiles({});
+    sectionFilesRef.current = {};
+    setProjectActions({});
+    projectActionsRef.current = {};
+    setProjectLoading({});
+    projectLoadingRef.current = {};
+    setLoadingSections(new Set());
+    loadingSectionsRef.current = new Set();
+    setPendingProjects([]);
+  }, [setPendingProjects]);
+
+  const resolveReadmeFile = React.useCallback(
+    async (folderPath: string): Promise<MarkdownFile> => {
+      const normalizedFolderPath =
+        normalizeSidebarPath(folderPath) ?? folderPath.replace(/\\/g, '/');
+      const markdownPath = `${normalizedFolderPath}/README.markdown`;
+      const mdPath = `${normalizedFolderPath}/README.md`;
+      const markdownExists = await withErrorHandling(async () => {
+        return safeInvoke<boolean>('check_file_exists', { filePath: markdownPath }, false);
+      }, 'Failed to resolve overview file', 'workspace-sidebar');
+      const filePath = markdownExists ? markdownPath : mdPath;
+
+      return {
+        id: filePath,
+        name: markdownExists ? 'README.markdown' : 'README.md',
+        path: filePath,
+        size: 0,
+        last_modified: Math.floor(Date.now() / 1000),
+        extension: markdownExists ? '.markdown' : '.md',
+      };
+    },
+    [withErrorHandling]
+  );
+
+  const syncHorizonReadme = React.useCallback(
+    async (folderPath: string, files: MarkdownFile[]) => {
+      const folderName = getFolderName(folderPath);
+      const horizonType = HORIZON_FOLDER_TO_TYPE[folderName];
+      if (!horizonType) return;
+
+      const existingReadme = files.find((file) => /^README\.(md|markdown)$/i.test(file.name));
+      const readmePath = existingReadme?.path ?? `${folderPath}/README.md`;
+      const filteredFiles = files.filter((file) => !/^README\.(md|markdown)$/i.test(file.name));
+
+      const existingContent = await withErrorHandling(async () => {
+        return safeInvoke<string>('read_file', { path: readmePath }, null);
+      }, 'Failed to read horizon overview', 'workspace-sidebar');
+
+      if (typeof existingContent !== 'string') {
+        if (existingReadme) {
+          return;
+        }
+
+        const { content } = buildHorizonReadmeMarkdown({
+          horizon: horizonType,
+          referencePaths: filteredFiles.map((file) => norm(file.path) ?? file.path),
+        });
+
+        const writeResult = await withErrorHandling(async () => {
+          const result = await safeInvoke('save_file', { path: readmePath, content }, null);
+          if (!result) {
+            throw new Error('Failed to create horizon overview');
+          }
+          return result;
+        }, 'Failed to create horizon overview', 'workspace-sidebar');
+
+        if (!writeResult) {
+          return;
+        }
+
+        return;
+      }
+
+      try {
+        const { content, changed } = syncHorizonReadmeContent({
+          horizon: horizonType,
+          existingContent,
+          files: filteredFiles,
+        });
+        if (changed) {
+          const saveResult = await withErrorHandling(async () => {
+            const result = await safeInvoke('save_file', { path: readmePath, content }, null);
+            if (!result) {
+              throw new Error('Failed to save horizon overview');
+            }
+            return result;
+          }, 'Failed to save horizon overview', 'workspace-sidebar');
+
+          if (!saveResult) {
+            return;
+          }
+        }
+      } catch (error) {
+        console.error('Failed to sync horizon README', { folderPath, error });
+      }
+    },
+    [withErrorHandling]
+  );
+
+  const resolveSectionLoadPath = React.useCallback(
+    async (sectionId: string, root: string): Promise<string | null> => {
+      const section = GTD_SECTIONS.find((candidate) => candidate.id === sectionId);
+      if (!section || section.id === 'calendar' || section.id === 'projects') {
+        return null;
+      }
+
+      const candidatePaths = buildSectionPathCandidates(root, section);
+      if (candidatePaths.length <= 1) {
+        return candidatePaths[0] ?? null;
+      }
+
+      for (const candidatePath of candidatePaths) {
+        const exists = await withErrorHandling(
+          async () =>
+            safeInvoke<boolean>(
+              'check_directory_exists',
+              { path: candidatePath },
+              false
+            ),
+          'Failed to verify section directory'
+        );
+        if (exists) {
+          return candidatePath;
+        }
+      }
+
+      return candidatePaths[0] ?? null;
+    },
+    [withErrorHandling]
+  );
+
+  const resolveSectionLoadPaths = React.useCallback(
+    async (sectionIds: readonly string[], root: string): Promise<string[]> => {
+      const resolvedPaths = await Promise.all(
+        sectionIds.map((sectionId) => resolveSectionLoadPath(sectionId, root))
+      );
+
+      return [...new Set(resolvedPaths.filter((path): path is string => Boolean(path)))];
+    },
+    [resolveSectionLoadPath]
+  );
+
+  const resolveExistingSectionPath = React.useCallback(
+    async (sectionPath: string): Promise<string> => {
+      const normalizedPath =
+        normalizeSidebarPath(sectionPath) ?? sectionPath.replace(/\\/g, '/');
+      const sectionFromRoot = rootPath
+        ? GTD_SECTIONS.find((candidate) => {
+            if (candidate.id === 'calendar' || candidate.id === 'projects') {
+              return false;
+            }
+
+            return buildSectionPathCandidates(rootPath, candidate).some((candidatePath) =>
+              isUnder(norm(normalizedPath), norm(candidatePath))
+            );
+          })
+        : null;
+      const inferredContext = inferSectionContextFromPath(normalizedPath);
+      const section = sectionFromRoot ?? inferredContext?.section;
+      const candidateRoot = rootPath ?? inferredContext?.root;
+
+      if (!section || !candidateRoot) {
+        return normalizedPath;
+      }
+
+      const candidatePaths = buildSectionPathCandidates(candidateRoot, section);
+      const orderedPaths = candidatePaths.includes(normalizedPath)
+        ? [normalizedPath, ...candidatePaths.filter((candidate) => candidate !== normalizedPath)]
+        : candidatePaths;
+
+      for (const candidatePath of orderedPaths) {
+        const exists = await withErrorHandling(
+          async () =>
+            safeInvoke<boolean>(
+              'check_directory_exists',
+              { path: candidatePath },
+              false
+            ),
+          'Failed to verify section directory'
+        );
+        if (exists === true) {
+          return candidatePath;
+        }
+      }
+
+      return normalizedPath;
+    },
+    [rootPath, withErrorHandling]
+  );
+
+  const loadSectionFiles = React.useCallback(
+    async (sectionPath: string, force: boolean = false): Promise<MarkdownFile[]> => {
+      const generationAtStart = workspaceGenerationRef.current;
+      const requestedKey =
+        normalizeSidebarPath(sectionPath) ?? sectionPath.replace(/\\/g, '/');
+      const normalizedKey = await resolveExistingSectionPath(sectionPath);
+      const current =
+        sectionFilesRef.current[normalizedKey] ?? sectionFilesRef.current[requestedKey];
+      if (!force && current) {
+        return current;
+      }
+
+      const directoryExists = await withErrorHandling(async () => {
+        return safeInvoke<boolean>(
+          'check_directory_exists',
+          { path: normalizedKey },
+          null
+        );
+      }, 'Failed to check section directory', 'workspace-sidebar');
+      if (directoryExists !== true) {
+        return current || [];
+      }
+
+      if (loadingSectionsRef.current.has(normalizedKey)) {
+        return current || [];
+      }
+
+      loadingSectionsRef.current.add(normalizedKey);
+      setLoadingSections((prev) => {
+        const next = new Set(prev);
+        next.add(normalizedKey);
+        return next;
+      });
+
+      try {
+        const files = await withErrorHandling(async () => {
+          const result = await safeInvoke<MarkdownFile[]>(
+            'list_markdown_files',
+            { path: normalizedKey },
+            null
+          );
+          if (result == null) {
+            throw new Error(`Failed to load section files for ${normalizedKey}`);
+          }
+          return result;
+        }, 'Failed to load section files', 'workspace-sidebar');
+        if (files === undefined || files === null) {
+          return current || [];
+        }
+        const sortedFiles = sortMarkdownFiles(files);
+
+        if (workspaceGenerationRef.current !== generationAtStart) {
+          return current || [];
+        }
+
+        setSectionFiles((prev) => {
+          const next = { ...prev };
+          if (normalizedKey !== requestedKey) {
+            delete next[requestedKey];
+          }
+          next[normalizedKey] = sortedFiles;
+          return next;
+        });
+        setLoadedSections((prev) => {
+          const next = new Set(prev);
+          if (normalizedKey !== requestedKey) {
+            next.delete(requestedKey);
+          }
+          next.add(normalizedKey);
+          return next;
+        });
+
+        if (workspaceGenerationRef.current !== generationAtStart) {
+          return sortedFiles;
+        }
+
+        await syncHorizonReadme(normalizedKey, sortedFiles);
+        return sortedFiles;
+      } catch {
+        return current || [];
+      } finally {
+        loadingSectionsRef.current.delete(normalizedKey);
+        setLoadingSections((prev) => {
+          const next = new Set(prev);
+          next.delete(normalizedKey);
+          return next;
+        });
+      }
+    },
+    [resolveExistingSectionPath, syncHorizonReadme, withErrorHandling]
+  );
+
+  const loadProjectActions = React.useCallback(
+    async (projectPath: string) => {
+      const generationAtStart = workspaceGenerationRef.current;
+      const normalizedKey =
+        normalizeSidebarPath(projectPath) ?? projectPath.replace(/\\/g, '/');
+      if (projectLoadingRef.current[normalizedKey]) {
+        return;
+      }
+
+      projectLoadingRef.current = {
+        ...projectLoadingRef.current,
+        [normalizedKey]: true,
+      };
+      setProjectLoading((prev) => ({
+        ...prev,
+        [normalizedKey]: true,
+      }));
+
+      try {
+        let files = await withErrorHandling(async () => {
+          return safeInvoke<MarkdownFile[]>(
+            'list_project_actions',
+            { projectPath: normalizedKey },
+            null
+          );
+        }, 'Failed to load project actions', 'workspace-sidebar');
+        files = files ?? [];
+        if (files.length === 0) {
+          const all = await withErrorHandling(async () => {
+            const result = await safeInvoke<MarkdownFile[]>(
+              'list_markdown_files',
+              { path: normalizedKey },
+              null
+            );
+            if (result == null) {
+              throw new Error(`Failed to load project files for ${normalizedKey}`);
+            }
+            return result;
+          }, 'Failed to load project files', 'workspace-sidebar');
+          files = (all ?? []).filter((file) => !/^README\.(md|markdown)$/i.test(file.name));
+        }
+
+        if (workspaceGenerationRef.current !== generationAtStart) {
+          return;
+        }
+
+        flushSync(() => {
+          setProjectActions((prev) => ({
+            ...prev,
+            [normalizedKey]: files ?? [],
+          }));
+        });
+
+        const statusResults = await Promise.all(
+          (files ?? []).map(async (action) => {
+            try {
+              const content = await readFileText(action.path);
+              const parsedAction = parseActionMarkdown(content);
+              const normalizedActionPath =
+                normalizeSidebarPath(action.path) ?? action.path.replace(/\\/g, '/');
+              return {
+                path: normalizedActionPath,
+                status: parsedAction.status || 'in-progress',
+                due_date: parsedAction.dueDate || '',
+              };
+            } catch {
+              return {
+                path:
+                  normalizeSidebarPath(action.path) ?? action.path.replace(/\\/g, '/'),
+                status: 'in-progress',
+                due_date: '',
+              };
+            }
+          })
+        );
+
+        if (workspaceGenerationRef.current !== generationAtStart) {
+          return;
+        }
+
+        const nextStatuses = Object.fromEntries(
+          statusResults.map((result) => [result.path, result.status])
+        );
+
+        flushSync(() => {
+          overlays.setActionStatuses((prev) => ({
+            ...prev,
+            ...nextStatuses,
+          }));
+          setProjectLoading((prev) => {
+            const next = { ...prev };
+            delete next[normalizedKey];
+            return next;
+          });
+        });
+        projectLoadingRef.current = Object.fromEntries(
+          Object.entries(projectLoadingRef.current).filter(([path]) => path !== normalizedKey)
+        );
+
+        overlays.setActionMetadata((prev) => {
+          const next = { ...prev };
+          statusResults.forEach(({ path, due_date }) => {
+            if (due_date) {
+              next[path] = {
+                ...next[path],
+                due_date,
+              };
+            } else if (next[path]) {
+              const { due_date: _ignored, ...rest } = next[path];
+              next[path] = rest;
+            }
+          });
+          return next;
+        });
+      } catch {
+        // Keep existing project action state when a refresh fails.
+      } finally {
+        if (workspaceGenerationRef.current === generationAtStart) {
+          projectLoadingRef.current = Object.fromEntries(
+            Object.entries(projectLoadingRef.current).filter(([path]) => path !== normalizedKey)
+          );
+          setProjectLoading((prev) => {
+            if (!(normalizedKey in prev)) {
+              return prev;
+            }
+            const next = { ...prev };
+            delete next[normalizedKey];
+            return next;
+          });
+        }
+      }
+    },
+    [overlays, withErrorHandling]
+  );
+
+  return {
+    sectionFiles,
+    setSectionFiles,
+    sectionFilesRef,
+    projectActions,
+    setProjectActions,
+    projectActionsRef,
+    projectLoading,
+    setProjectLoading,
+    projectLoadingRef,
+    loadingSections,
+    setLoadingSections,
+    loadingSectionsRef,
+    loadedSections,
+    setLoadedSections,
+    pendingProjects,
+    setPendingProjects,
+    lastRootRef,
+    preloadedRef,
+    workspaceGenerationRef,
+    resetDataState,
+    resolveReadmeFile,
+    resolveSectionLoadPaths,
+    loadSectionFiles,
+    loadProjectActions,
+  };
+}

--- a/src/hooks/sidebar/useSidebarEventBridge.ts
+++ b/src/hooks/sidebar/useSidebarEventBridge.ts
@@ -178,20 +178,30 @@ export function useSidebarEventBridge({
                   path === pathMatch.projectPath ? normalizedNewProjectPath : path
                 )
               );
-              setProjectActions((prev) =>
-                prev[pathMatch.projectPath]
-                  ? {
-                      ...prev,
-                    }
-                  : prev
-              );
+              setProjectActions((prev) => {
+                if (!prev[pathMatch.projectPath]) {
+                  return prev;
+                }
+
+                const {
+                  [pathMatch.projectPath]: existingActions,
+                  ...rest
+                } = prev;
+
+                return {
+                  ...rest,
+                  [normalizedNewProjectPath]: existingActions,
+                };
+              });
 
               if (rootPath) {
                 await loadProjects(rootPath);
                 removeProjectOverlay(pathMatch.projectPath);
                 setProjectActions((prev) => {
                   const next = { ...prev };
-                  delete next[pathMatch.projectPath!];
+                  if (pathMatch.projectPath !== normalizedNewProjectPath) {
+                    delete next[pathMatch.projectPath!];
+                  }
                   return next;
                 });
               }

--- a/src/hooks/sidebar/useSidebarEventBridge.ts
+++ b/src/hooks/sidebar/useSidebarEventBridge.ts
@@ -1,0 +1,440 @@
+import React from 'react';
+import { safeInvoke } from '@/utils/safe-invoke';
+import {
+  onContentChange,
+  onContentSaved,
+  onMetadataChange,
+} from '@/utils/content-event-bus';
+import type {
+  SidebarEventBridgeDeps,
+} from '@/hooks/sidebar/types';
+import {
+  classifySidebarPath,
+  extractParentFolder,
+  normalizeSidebarPath,
+} from '@/hooks/sidebar/path-classification';
+import type { FileOperationResult, GTDProject } from '@/types';
+import { norm } from '@/utils/path';
+
+const RELOAD_SECTION_IDS = [
+  'someday',
+  'cabinet',
+  'habits',
+  'areas',
+  'goals',
+  'vision',
+  'purpose',
+] as const;
+const RELOAD_SECTION_ID_SET = new Set<string>(RELOAD_SECTION_IDS);
+
+function getDueDateFromMetadata(metadata: Record<string, unknown>): string | undefined {
+  const dueDate = metadata.dueDate;
+  if (typeof dueDate === 'string') {
+    return dueDate;
+  }
+
+  const snakeCase = metadata.due_date;
+  return typeof snakeCase === 'string' ? snakeCase : undefined;
+}
+
+export function useSidebarEventBridge({
+  rootPath,
+  withErrorHandling,
+  loadProjects,
+  loadProjectActions,
+  loadSectionFiles,
+  overlays,
+  ui,
+  data,
+}: SidebarEventBridgeDeps): void {
+  const {
+    setActionStatuses,
+    updateProjectOverlay,
+    updateActionOverlay,
+    updateSectionFileOverlay,
+    removeProjectOverlay,
+    removeActionOverlay,
+    removeSectionFileOverlay,
+  } = overlays;
+  const { setExpandedProjects } = ui;
+  const { setPendingProjects, setProjectActions } = data;
+
+  React.useEffect(() => {
+    const unsubscribeMetadata = onMetadataChange((event) => {
+      const { filePath, metadata, changedFields } = event;
+      const pathMatch = classifySidebarPath(filePath, rootPath);
+
+      if (pathMatch.kind === 'project-readme' && pathMatch.projectPath) {
+        if (changedFields?.status || changedFields?.projectStatus) {
+          const nextStatus = metadata.projectStatus || metadata.status;
+          if (nextStatus) {
+            updateProjectOverlay(pathMatch.projectPath, { status: String(nextStatus) });
+          } else {
+            updateProjectOverlay(pathMatch.projectPath, { status: '' });
+          }
+        }
+
+        if (changedFields?.due_date || changedFields?.dueDate || changedFields?.datetime) {
+          const nextDue = getDueDateFromMetadata(metadata as Record<string, unknown>);
+          if (typeof nextDue === 'string') {
+            updateProjectOverlay(pathMatch.projectPath, { due_date: nextDue });
+          } else {
+            updateProjectOverlay(pathMatch.projectPath, { due_date: undefined });
+          }
+        }
+      }
+
+      if (pathMatch.kind === 'project-action') {
+        if (changedFields?.status) {
+          const nextStatus = metadata.status ? String(metadata.status) : '';
+          setActionStatuses((prev) => {
+            const next = { ...prev };
+            if (nextStatus) {
+              next[pathMatch.normalizedPath] = nextStatus;
+            } else {
+              delete next[pathMatch.normalizedPath];
+            }
+            return next;
+          });
+          updateActionOverlay(pathMatch.normalizedPath, {
+            status: nextStatus || undefined,
+          });
+        }
+
+        if (changedFields?.due_date || changedFields?.dueDate || changedFields?.datetime) {
+          const nextDue = getDueDateFromMetadata(metadata as Record<string, unknown>);
+          updateActionOverlay(pathMatch.normalizedPath, {
+            due_date: typeof nextDue === 'string' ? nextDue : undefined,
+          });
+        }
+      }
+
+      if (
+        pathMatch.kind === 'section-file' &&
+        pathMatch.sectionId &&
+        RELOAD_SECTION_ID_SET.has(pathMatch.sectionId)
+      ) {
+        const folderPath =
+          pathMatch.sectionPath ?? extractParentFolder(pathMatch.normalizedPath);
+        if (folderPath) {
+          void loadSectionFiles(folderPath, true);
+        }
+      }
+    });
+
+    const unsubscribeChanged = onContentChange((event) => {
+      const { filePath, metadata, changedFields } = event;
+      const pathMatch = classifySidebarPath(filePath, rootPath);
+
+      if (pathMatch.kind === 'project-readme' && pathMatch.projectPath) {
+        if (changedFields?.dueDate || changedFields?.due_date || changedFields?.datetime) {
+          const nextDue = getDueDateFromMetadata(metadata as Record<string, unknown>);
+          if (typeof nextDue === 'string') {
+            updateProjectOverlay(pathMatch.projectPath, { due_date: nextDue });
+          } else {
+            updateProjectOverlay(pathMatch.projectPath, { due_date: undefined });
+          }
+        }
+      }
+    });
+
+    const unsubscribeSaved = onContentSaved(async (event) => {
+      const { filePath, metadata } = event;
+      const pathMatch = classifySidebarPath(filePath, rootPath);
+
+      if (pathMatch.kind === 'project-readme' && pathMatch.projectPath) {
+        const nextTitle = metadata.title;
+
+        if (nextTitle) {
+          const currentProjectName = pathMatch.projectPath.split('/').pop();
+
+          if (currentProjectName && currentProjectName !== nextTitle) {
+            await withErrorHandling(async () => {
+              const newProjectPath = await safeInvoke<string>(
+                'rename_gtd_project',
+                {
+                  oldProjectPath: pathMatch.projectPath,
+                  newProjectName: nextTitle,
+                },
+                null
+              );
+              if (!newProjectPath || typeof newProjectPath !== 'string') {
+                throw new Error('rename_gtd_project failed');
+              }
+
+              const normalizedNewProjectPath =
+                normalizeSidebarPath(newProjectPath) ?? newProjectPath;
+              updateProjectOverlay(pathMatch.projectPath, {
+                title: String(nextTitle),
+                currentPath: normalizedNewProjectPath,
+              });
+              updateProjectOverlay(normalizedNewProjectPath, {
+                title: String(nextTitle),
+                currentPath: normalizedNewProjectPath,
+              });
+
+              setExpandedProjects((prev) =>
+                prev.map((path) =>
+                  path === pathMatch.projectPath ? normalizedNewProjectPath : path
+                )
+              );
+              setProjectActions((prev) =>
+                prev[pathMatch.projectPath]
+                  ? {
+                      ...prev,
+                    }
+                  : prev
+              );
+
+              if (rootPath) {
+                await loadProjects(rootPath);
+                removeProjectOverlay(pathMatch.projectPath);
+                setProjectActions((prev) => {
+                  const next = { ...prev };
+                  delete next[pathMatch.projectPath!];
+                  return next;
+                });
+              }
+
+              window.dispatchEvent(
+                new CustomEvent('project-renamed', {
+                  detail: {
+                    oldPath: pathMatch.projectPath,
+                    newPath: normalizedNewProjectPath,
+                    newName: nextTitle,
+                  },
+                })
+              );
+            }, 'Failed to rename project', 'workspace-sidebar');
+          }
+        }
+
+        const nextDue = getDueDateFromMetadata(metadata as Record<string, unknown>);
+        if (typeof nextDue === 'string') {
+          updateProjectOverlay(pathMatch.projectPath, { due_date: nextDue });
+        } else {
+          updateProjectOverlay(pathMatch.projectPath, { due_date: undefined });
+        }
+
+        if (rootPath) {
+          await loadProjects(rootPath);
+        }
+      }
+
+      if (pathMatch.kind === 'project-action') {
+        const nextTitle = metadata.title;
+        if (nextTitle) {
+          const currentActionName = pathMatch.normalizedPath
+            .split('/')
+            .pop()
+            ?.replace(/\.(md|markdown)$/i, '');
+          if (currentActionName && currentActionName !== nextTitle) {
+            await withErrorHandling(async () => {
+              const newActionPath = await safeInvoke<string>(
+                'rename_gtd_action',
+                {
+                  oldActionPath: pathMatch.normalizedPath,
+                  newActionName: nextTitle,
+                },
+                null
+              );
+              if (!newActionPath || typeof newActionPath !== 'string') {
+                throw new Error('rename_gtd_action failed');
+              }
+
+              const normalizedNewActionPath =
+                normalizeSidebarPath(newActionPath) ?? newActionPath;
+              updateActionOverlay(pathMatch.normalizedPath, {
+                title: String(nextTitle),
+                currentPath: normalizedNewActionPath,
+              });
+              updateActionOverlay(normalizedNewActionPath, {
+                title: String(nextTitle),
+                currentPath: normalizedNewActionPath,
+              });
+
+              if (pathMatch.projectPath) {
+                await loadProjectActions(pathMatch.projectPath);
+              }
+              removeActionOverlay(pathMatch.normalizedPath);
+
+              window.dispatchEvent(
+                new CustomEvent('action-renamed', {
+                  detail: {
+                    oldPath: pathMatch.normalizedPath,
+                    newPath: normalizedNewActionPath,
+                    newName: nextTitle,
+                  },
+                })
+              );
+              window.dispatchEvent(
+                new CustomEvent('file-renamed', {
+                  detail: {
+                    oldPath: pathMatch.normalizedPath,
+                    newPath: normalizedNewActionPath,
+                  },
+                })
+              );
+            }, 'Failed to rename action', 'workspace-sidebar');
+          }
+        }
+      }
+
+      if (
+        pathMatch.kind === 'section-file' &&
+        pathMatch.sectionId &&
+        RELOAD_SECTION_ID_SET.has(pathMatch.sectionId)
+      ) {
+        const nextTitle = metadata.title;
+
+        if (nextTitle) {
+          const currentFileName = pathMatch.normalizedPath
+            .split('/')
+            .pop()
+            ?.replace(/\.(md|markdown)$/i, '');
+          if (
+            currentFileName &&
+            currentFileName.toLowerCase() !== 'readme' &&
+            currentFileName !== nextTitle
+          ) {
+            await withErrorHandling(async () => {
+              const renameResult = await safeInvoke<FileOperationResult>(
+                'rename_file',
+                { oldPath: pathMatch.normalizedPath, newName: nextTitle },
+                null
+              );
+              if (!renameResult?.success || !renameResult.path) {
+                throw new Error(renameResult?.message || 'rename_file failed');
+              }
+              const newFilePath = renameResult.path;
+
+              const normalizedNewFilePath =
+                normalizeSidebarPath(newFilePath) ?? newFilePath;
+              updateSectionFileOverlay(pathMatch.normalizedPath, {
+                title: String(nextTitle),
+                currentPath: normalizedNewFilePath,
+              });
+              updateSectionFileOverlay(normalizedNewFilePath, {
+                title: String(nextTitle),
+                currentPath: normalizedNewFilePath,
+              });
+
+              const folderPath =
+                pathMatch.sectionPath ?? extractParentFolder(pathMatch.normalizedPath);
+              if (folderPath) {
+                await loadSectionFiles(folderPath, true);
+              }
+              removeSectionFileOverlay(pathMatch.normalizedPath);
+
+              window.dispatchEvent(
+                new CustomEvent('section-file-renamed', {
+                  detail: {
+                    oldPath: pathMatch.normalizedPath,
+                    newPath: normalizedNewFilePath,
+                    newName: nextTitle,
+                  },
+                })
+              );
+              window.dispatchEvent(
+                new CustomEvent('file-renamed', {
+                  detail: {
+                    oldPath: pathMatch.normalizedPath,
+                    newPath: normalizedNewFilePath,
+                  },
+                })
+              );
+            }, 'Failed to rename file', 'workspace-sidebar');
+          }
+        }
+      }
+    });
+
+    const handleProjectCreated = async (event: Event) => {
+      const customEvent = event as CustomEvent<{
+        projectPath?: string;
+        projectName?: string;
+      }>;
+      const { projectPath, projectName } = customEvent.detail ?? {};
+
+      if (projectPath && projectName) {
+        const optimistic: GTDProject = {
+          name: projectName,
+          description: '',
+          dueDate: undefined,
+          status: 'in-progress',
+          path: projectPath,
+          createdDateTime: new Date().toISOString(),
+          action_count: 0,
+        };
+
+        setPendingProjects((prev) =>
+          prev.some(
+            (project) =>
+              (norm(project.path) ?? project.path) ===
+              (norm(optimistic.path) ?? optimistic.path)
+          )
+            ? prev
+            : [...prev, optimistic]
+        );
+      }
+
+      if (rootPath) {
+        const projects = await loadProjects(rootPath);
+        setPendingProjects((prev) =>
+          prev.filter(
+            (project) =>
+              !projects.some(
+                (loaded) =>
+                  (norm(loaded.path) ?? loaded.path) ===
+                  (norm(project.path) ?? project.path)
+              )
+          )
+        );
+      }
+    };
+
+    const handleActionCreated = async (event: Event) => {
+      const customEvent = event as CustomEvent<{ projectPath?: string }>;
+      const projectPath = customEvent.detail?.projectPath;
+      if (!projectPath) return;
+
+      await loadProjectActions(projectPath);
+      if (rootPath) {
+        await loadProjects(rootPath);
+      }
+    };
+
+    window.addEventListener('gtd-project-created', handleProjectCreated as EventListener);
+    window.addEventListener('gtd-action-created', handleActionCreated as EventListener);
+
+    return () => {
+      unsubscribeMetadata();
+      unsubscribeChanged();
+      unsubscribeSaved();
+      window.removeEventListener(
+        'gtd-project-created',
+        handleProjectCreated as EventListener
+      );
+      window.removeEventListener(
+        'gtd-action-created',
+        handleActionCreated as EventListener
+      );
+    };
+  }, [
+    loadProjectActions,
+    loadProjects,
+    loadSectionFiles,
+    removeActionOverlay,
+    removeProjectOverlay,
+    removeSectionFileOverlay,
+    rootPath,
+    setActionStatuses,
+    setExpandedProjects,
+    setPendingProjects,
+    setProjectActions,
+    updateActionOverlay,
+    updateProjectOverlay,
+    updateSectionFileOverlay,
+    withErrorHandling,
+  ]);
+}

--- a/src/hooks/sidebar/useSidebarOverlays.ts
+++ b/src/hooks/sidebar/useSidebarOverlays.ts
@@ -1,0 +1,123 @@
+import React from 'react';
+import type {
+  SidebarActionMetadata,
+  SidebarProjectMetadata,
+  SidebarSectionFileMetadata,
+} from '@/components/gtd/sidebar/types';
+import type { SidebarOverlayState } from '@/hooks/sidebar/types';
+import { normalizeSidebarPath } from '@/hooks/sidebar/path-classification';
+
+export function useSidebarOverlays(): SidebarOverlayState {
+  const [projectMetadata, setProjectMetadata] = React.useState<
+    Record<string, SidebarProjectMetadata>
+  >({});
+  const [actionMetadata, setActionMetadata] = React.useState<
+    Record<string, SidebarActionMetadata>
+  >({});
+  const [sectionFileMetadata, setSectionFileMetadata] = React.useState<
+    Record<string, SidebarSectionFileMetadata>
+  >({});
+  const [actionStatuses, setActionStatuses] = React.useState<Record<string, string>>(
+    {}
+  );
+
+  const updateProjectOverlay = React.useCallback(
+    (projectPath: string, patch: Partial<SidebarProjectMetadata>) => {
+      const normalizedKey =
+        normalizeSidebarPath(projectPath) ?? projectPath.replace(/\\/g, '/');
+      setProjectMetadata((prev) => ({
+        ...prev,
+        [normalizedKey]: {
+          ...prev[normalizedKey],
+          ...patch,
+        },
+      }));
+    },
+    []
+  );
+
+  const updateActionOverlay = React.useCallback(
+    (actionPath: string, patch: Partial<SidebarActionMetadata>) => {
+      const normalizedKey =
+        normalizeSidebarPath(actionPath) ?? actionPath.replace(/\\/g, '/');
+      setActionMetadata((prev) => ({
+        ...prev,
+        [normalizedKey]: {
+          ...prev[normalizedKey],
+          ...patch,
+        },
+      }));
+    },
+    []
+  );
+
+  const updateSectionFileOverlay = React.useCallback(
+    (filePath: string, patch: Partial<SidebarSectionFileMetadata>) => {
+      const normalizedKey =
+        normalizeSidebarPath(filePath) ?? filePath.replace(/\\/g, '/');
+      setSectionFileMetadata((prev) => ({
+        ...prev,
+        [normalizedKey]: {
+          ...prev[normalizedKey],
+          ...patch,
+        },
+      }));
+    },
+    []
+  );
+
+  const removeActionOverlay = React.useCallback((filePath: string) => {
+    const normalizedKey =
+      normalizeSidebarPath(filePath) ?? filePath.replace(/\\/g, '/');
+    setActionMetadata((prev) => {
+      const next = { ...prev };
+      delete next[normalizedKey];
+      return next;
+    });
+  }, []);
+
+  const removeProjectOverlay = React.useCallback((projectPath: string) => {
+    const normalizedKey =
+      normalizeSidebarPath(projectPath) ?? projectPath.replace(/\\/g, '/');
+    setProjectMetadata((prev) => {
+      const next = { ...prev };
+      delete next[normalizedKey];
+      return next;
+    });
+  }, []);
+
+  const removeSectionFileOverlay = React.useCallback((filePath: string) => {
+    const normalizedKey =
+      normalizeSidebarPath(filePath) ?? filePath.replace(/\\/g, '/');
+    setSectionFileMetadata((prev) => {
+      const next = { ...prev };
+      delete next[normalizedKey];
+      return next;
+    });
+  }, []);
+
+  const resetOverlays = React.useCallback(() => {
+    setProjectMetadata({});
+    setActionMetadata({});
+    setSectionFileMetadata({});
+    setActionStatuses({});
+  }, []);
+
+  return {
+    projectMetadata,
+    actionMetadata,
+    sectionFileMetadata,
+    actionStatuses,
+    setProjectMetadata,
+    setActionMetadata,
+    setSectionFileMetadata,
+    setActionStatuses,
+    updateProjectOverlay,
+    updateActionOverlay,
+    updateSectionFileOverlay,
+    removeProjectOverlay,
+    removeActionOverlay,
+    removeSectionFileOverlay,
+    resetOverlays,
+  };
+}

--- a/src/hooks/sidebar/useSidebarUiState.ts
+++ b/src/hooks/sidebar/useSidebarUiState.ts
@@ -1,0 +1,92 @@
+import React from 'react';
+import type {
+  PageDialogDirectory,
+  SidebarDeleteItem,
+} from '@/components/gtd/sidebar/types';
+import type { SidebarUiState } from '@/hooks/sidebar/types';
+import { normalizeSidebarPath } from '@/hooks/sidebar/path-classification';
+import type { GTDProject } from '@/types';
+
+export function useSidebarUiState(): SidebarUiState {
+  const [showProjectDialog, setShowProjectDialog] = React.useState(false);
+  const [showActionDialog, setShowActionDialog] = React.useState(false);
+  const [selectedProject, setSelectedProject] = React.useState<GTDProject | null>(
+    null
+  );
+  const [expandedSections, setExpandedSections] = React.useState<string[]>([
+    'projects',
+    'habits',
+  ]);
+  const [expandedProjects, setExpandedProjects] = React.useState<string[]>([]);
+  const [completedProjectsExpanded, setCompletedProjectsExpanded] =
+    React.useState(false);
+  const [cancelledProjectsExpanded, setCancelledProjectsExpanded] =
+    React.useState(false);
+  const [expandedCompletedActions, setExpandedCompletedActions] =
+    React.useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = React.useState('');
+  const [showSearch, setShowSearch] = React.useState(false);
+  const [showPageDialog, setShowPageDialog] = React.useState(false);
+  const [pageDialogDirectory, setPageDialogDirectory] =
+    React.useState<PageDialogDirectory | null>(null);
+  const [showHabitDialog, setShowHabitDialog] = React.useState(false);
+  const [deleteItem, setDeleteItem] = React.useState<SidebarDeleteItem | null>(
+    null
+  );
+
+  const toggleSection = React.useCallback((sectionId: string) => {
+    setExpandedSections((prev) =>
+      prev.includes(sectionId)
+        ? prev.filter((id) => id !== sectionId)
+        : [...prev, sectionId]
+    );
+  }, []);
+
+  const toggleCompletedActions = React.useCallback((projectPath: string) => {
+    const normalizedProjectPath =
+      normalizeSidebarPath(projectPath) ?? projectPath.replace(/\\/g, '/');
+
+    setExpandedCompletedActions((prev) => {
+      const next = new Set(prev);
+      if (next.has(normalizedProjectPath)) {
+        next.delete(normalizedProjectPath);
+      } else {
+        next.add(normalizedProjectPath);
+      }
+      return next;
+    });
+  }, []);
+
+  return {
+    showProjectDialog,
+    setShowProjectDialog,
+    showActionDialog,
+    setShowActionDialog,
+    selectedProject,
+    setSelectedProject,
+    expandedSections,
+    setExpandedSections,
+    expandedProjects,
+    setExpandedProjects,
+    completedProjectsExpanded,
+    setCompletedProjectsExpanded,
+    cancelledProjectsExpanded,
+    setCancelledProjectsExpanded,
+    expandedCompletedActions,
+    setExpandedCompletedActions,
+    searchQuery,
+    setSearchQuery,
+    showSearch,
+    setShowSearch,
+    showPageDialog,
+    setShowPageDialog,
+    pageDialogDirectory,
+    setPageDialogDirectory,
+    showHabitDialog,
+    setShowHabitDialog,
+    deleteItem,
+    setDeleteItem,
+    toggleSection,
+    toggleCompletedActions,
+  };
+}

--- a/src/hooks/sidebar/useSidebarWorkspaceLifecycle.ts
+++ b/src/hooks/sidebar/useSidebarWorkspaceLifecycle.ts
@@ -1,0 +1,152 @@
+import React from 'react';
+import type { GTDProject } from '@/types';
+import type {
+  SidebarDataState,
+  SidebarOverlayState,
+} from '@/hooks/sidebar/types';
+import { normalizeSidebarPath } from '@/hooks/sidebar/path-classification';
+
+const PRELOAD_PRIORITY_SECTION_IDS = ['habits', 'areas', 'goals'] as const;
+const PRELOAD_SECONDARY_SECTION_IDS = [
+  'someday',
+  'cabinet',
+  'vision',
+  'purpose',
+] as const;
+
+type UseSidebarWorkspaceLifecycleArgs = {
+  currentFolder: string | null;
+  rootPath: string | null;
+  projects: GTDProject[] | null | undefined;
+  checkGTDSpace: (path: string) => Promise<boolean>;
+  loadProjects: (path: string) => Promise<GTDProject[]>;
+  loadProjectActions: (projectPath: string) => Promise<void>;
+  resolveSectionLoadPaths: (
+    sectionIds: readonly string[],
+    root: string
+  ) => Promise<string[]>;
+  loadSectionFiles: (sectionPath: string, force?: boolean) => Promise<unknown>;
+  data: Pick<
+    SidebarDataState,
+    | 'projectActions'
+    | 'projectLoading'
+    | 'resetDataState'
+    | 'lastRootRef'
+    | 'preloadedRef'
+    | 'workspaceGenerationRef'
+  >;
+  overlays: Pick<SidebarOverlayState, 'resetOverlays'>;
+};
+
+export function useSidebarWorkspaceLifecycle({
+  currentFolder,
+  rootPath,
+  projects,
+  checkGTDSpace,
+  loadProjects,
+  loadProjectActions,
+  resolveSectionLoadPaths,
+  loadSectionFiles,
+  data,
+  overlays,
+}: UseSidebarWorkspaceLifecycleArgs): void {
+  const {
+    projectActions,
+    projectLoading,
+    resetDataState,
+    lastRootRef,
+    preloadedRef,
+    workspaceGenerationRef,
+  } = data;
+  const { resetOverlays } = overlays;
+
+  React.useEffect(() => {
+    const pathToCheck = rootPath;
+    const normalizedRoot = normalizeSidebarPath(pathToCheck);
+    const normalizedCurrent = normalizeSidebarPath(currentFolder);
+    const normalizedRootWithSlash = normalizedRoot?.endsWith('/')
+      ? normalizedRoot
+      : `${normalizedRoot ?? ''}/`;
+
+    if (
+      !normalizedRoot ||
+      !normalizedCurrent ||
+      !(
+        normalizedCurrent === normalizedRoot ||
+        normalizedCurrent.startsWith(normalizedRootWithSlash)
+      )
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const preload = async () => {
+      if (lastRootRef.current !== pathToCheck) {
+        workspaceGenerationRef.current += 1;
+        preloadedRef.current = false;
+        lastRootRef.current = pathToCheck;
+        resetDataState();
+        resetOverlays();
+      }
+
+      const isGTD = await checkGTDSpace(pathToCheck);
+      if (!isGTD || cancelled) return;
+
+      if (!projects || projects.length === 0) {
+        await loadProjects(pathToCheck);
+        if (cancelled) return;
+      }
+
+      if (!preloadedRef.current) {
+        preloadedRef.current = true;
+
+        const priorityPaths = await resolveSectionLoadPaths(
+          PRELOAD_PRIORITY_SECTION_IDS,
+          pathToCheck
+        );
+        const secondaryPaths = await resolveSectionLoadPaths(
+          PRELOAD_SECONDARY_SECTION_IDS,
+          pathToCheck
+        );
+
+        await Promise.allSettled(priorityPaths.map((path) => loadSectionFiles(path)));
+        if (cancelled) return;
+
+        await Promise.allSettled(secondaryPaths.map((path) => loadSectionFiles(path)));
+      }
+    };
+
+    void preload();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    checkGTDSpace,
+    currentFolder,
+    lastRootRef,
+    loadProjects,
+    loadSectionFiles,
+    preloadedRef,
+    projects,
+    resetDataState,
+    resetOverlays,
+    resolveSectionLoadPaths,
+    rootPath,
+    workspaceGenerationRef,
+  ]);
+
+  React.useEffect(() => {
+    if (!projects || projects.length === 0) return;
+
+    const missingProjects = projects.filter((project) => {
+      const normalizedKey =
+        normalizeSidebarPath(project.path) ?? project.path.replace(/\\/g, '/');
+      return !projectActions[normalizedKey] && !projectLoading[normalizedKey];
+    });
+    if (missingProjects.length === 0) return;
+
+    void Promise.all(missingProjects.map((project) => loadProjectActions(project.path)));
+  }, [loadProjectActions, projectActions, projectLoading, projects]);
+}

--- a/src/hooks/useGTDWorkspaceSidebar.ts
+++ b/src/hooks/useGTDWorkspaceSidebar.ts
@@ -2,21 +2,13 @@ import React from 'react';
 import { flushSync } from 'react-dom';
 import { safeInvoke } from '@/utils/safe-invoke';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
-import { readFileText } from '@/hooks/useFileManager';
-import { onContentChange, onContentSaved, onMetadataChange } from '@/utils/content-event-bus';
-import {
-  buildHorizonReadmeMarkdown,
-  syncHorizonReadmeContent,
-} from '@/utils/horizon-readme-utils';
-import { parseActionMarkdown } from '@/utils/gtd-action-markdown';
 import { useGTDSpace } from '@/hooks/useGTDSpace';
-import { GTD_SECTIONS, HORIZON_FOLDER_TO_TYPE } from '@/components/gtd/sidebar/constants';
+import { GTD_SECTIONS } from '@/components/gtd/sidebar/constants';
 import {
   buildSectionPath,
   buildSectionPathCandidates,
   buildSidebarSearchResults,
   getFolderName,
-  normalizePath,
   partitionProjectsByCompletion,
   sortMarkdownFiles,
 } from '@/components/gtd/sidebar/utils';
@@ -28,8 +20,17 @@ import type {
   SidebarProjectMetadata,
   SidebarSectionFileMetadata,
 } from '@/components/gtd/sidebar/types';
-import type { FileOperationResult, GTDProject, GTDSpace, MarkdownFile } from '@/types';
-import { norm, isUnder } from '@/utils/path';
+import { useSidebarDataLoaders } from '@/hooks/sidebar/useSidebarDataLoaders';
+import { useSidebarEventBridge } from '@/hooks/sidebar/useSidebarEventBridge';
+import {
+  buildSectionPath as buildCanonicalSectionPath,
+  normalizeSidebarPath,
+} from '@/hooks/sidebar/path-classification';
+import { useSidebarOverlays } from '@/hooks/sidebar/useSidebarOverlays';
+import { useSidebarUiState } from '@/hooks/sidebar/useSidebarUiState';
+import { useSidebarWorkspaceLifecycle } from '@/hooks/sidebar/useSidebarWorkspaceLifecycle';
+import type { GTDProject, GTDSpace, MarkdownFile } from '@/types';
+import { norm } from '@/utils/path';
 
 type UseGTDWorkspaceSidebarResult = {
   gtdSpace: GTDSpace | null;
@@ -95,63 +96,15 @@ type UseGTDWorkspaceSidebarResult = {
 
 type ControllerArgs = Pick<
   GTDWorkspaceSidebarProps,
-  'currentFolder' | 'onFolderSelect' | 'onFileSelect' | 'onRefresh' | 'gtdSpace' | 'checkGTDSpace' | 'loadProjects' | 'activeFilePath'
+  | 'currentFolder'
+  | 'onFolderSelect'
+  | 'onFileSelect'
+  | 'onRefresh'
+  | 'gtdSpace'
+  | 'checkGTDSpace'
+  | 'loadProjects'
+  | 'activeFilePath'
 >;
-
-const PRELOAD_PRIORITY_SECTION_IDS = ['habits', 'areas', 'goals'] as const;
-const PRELOAD_SECONDARY_SECTION_IDS = ['someday', 'cabinet', 'vision', 'purpose'] as const;
-const RELOAD_SECTION_IDS = ['someday', 'cabinet', 'habits', 'areas', 'goals', 'vision', 'purpose'] as const;
-
-function getSectionPathVariants(sectionId: string, rootPath?: string | null): string[] {
-  const section = GTD_SECTIONS.find((candidate) => candidate.id === sectionId);
-  if (!section) {
-    return [];
-  }
-
-  const names = Array.from(new Set([section.path, ...(section.aliases ?? [])]));
-  return names.map((name) => {
-    if (rootPath) {
-      return `${rootPath}/${name}`;
-    }
-    return `/${name}/`;
-  });
-}
-
-function getCombinedSectionPathVariants(
-  sectionIds: readonly string[],
-  rootPath?: string | null
-): string[] {
-  return sectionIds.flatMap((sectionId) => getSectionPathVariants(sectionId, rootPath));
-}
-
-function inferSectionContextFromPath(
-  normalizedPath: string
-): { root: string | null; section: (typeof GTD_SECTIONS)[number] } | null {
-  for (const section of GTD_SECTIONS) {
-    if (section.id === 'calendar' || section.id === 'projects') {
-      continue;
-    }
-
-    const candidateNames = Array.from(new Set([section.path, ...(section.aliases ?? [])]));
-    for (const candidateName of candidateNames) {
-      const marker = `/${candidateName}`;
-      const markerIndex = normalizedPath.lastIndexOf(marker);
-      if (markerIndex < 0) {
-        continue;
-      }
-
-      const nextChar = normalizedPath[markerIndex + marker.length];
-      if (nextChar !== undefined && nextChar !== '/') {
-        continue;
-      }
-
-      const inferredRoot = normalizedPath.slice(0, markerIndex) || null;
-      return { root: inferredRoot, section };
-    }
-  }
-
-  return null;
-}
 
 export function useGTDWorkspaceSidebar({
   currentFolder,
@@ -173,1010 +126,78 @@ export function useGTDWorkspaceSidebar({
   const gtdSpace = propGtdSpace ?? hookGtdSpace;
   const checkGTDSpace = propCheckGTDSpace ?? hookCheckGTDSpace;
   const loadProjects = propLoadProjects ?? hookLoadProjects;
-  const rootPath = gtdSpace?.root_path || currentFolder || null;
+  const workspaceRootPath = gtdSpace?.root_path ?? null;
+  const rootPath = workspaceRootPath || currentFolder || null;
   const { withErrorHandling } = useErrorHandler();
 
-  const [showProjectDialog, setShowProjectDialog] = React.useState(false);
-  const [showActionDialog, setShowActionDialog] = React.useState(false);
-  const [selectedProject, setSelectedProject] = React.useState<GTDProject | null>(null);
-  const [expandedSections, setExpandedSections] = React.useState<string[]>(['projects', 'habits']);
-  const [expandedProjects, setExpandedProjects] = React.useState<string[]>([]);
-  const [completedProjectsExpanded, setCompletedProjectsExpanded] = React.useState(false);
-  const [cancelledProjectsExpanded, setCancelledProjectsExpanded] = React.useState(false);
-  const [expandedCompletedActions, setExpandedCompletedActions] = React.useState<Set<string>>(
-    new Set()
-  );
-  const [projectActions, setProjectActions] = React.useState<Record<string, MarkdownFile[]>>({});
-  const [projectLoading, setProjectLoading] = React.useState<Record<string, boolean>>({});
-  const [actionStatuses, setActionStatuses] = React.useState<Record<string, string>>({});
-  const [searchQuery, setSearchQuery] = React.useState('');
-  const [showSearch, setShowSearch] = React.useState(false);
-  const [showPageDialog, setShowPageDialog] = React.useState(false);
-  const [pageDialogDirectory, setPageDialogDirectory] =
-    React.useState<PageDialogDirectory | null>(null);
-  const [showHabitDialog, setShowHabitDialog] = React.useState(false);
-  const [sectionFiles, setSectionFiles] = React.useState<Record<string, MarkdownFile[]>>({});
-  const [loadingSections, setLoadingSections] = React.useState<Set<string>>(new Set());
-  const [loadedSections, setLoadedSections] = React.useState<Set<string>>(new Set());
-  const [deleteItem, setDeleteItem] = React.useState<SidebarDeleteItem | null>(null);
-  const [projectMetadata, setProjectMetadata] = React.useState<
-    Record<string, SidebarProjectMetadata>
-  >({});
-  const [actionMetadata, setActionMetadata] = React.useState<Record<string, SidebarActionMetadata>>(
-    {}
-  );
-  const [sectionFileMetadata, setSectionFileMetadata] = React.useState<
-    Record<string, SidebarSectionFileMetadata>
-  >({});
-  const [pendingProjects, setPendingProjects] = React.useState<GTDProject[]>([]);
+  const ui = useSidebarUiState();
+  const overlays = useSidebarOverlays();
+  const data = useSidebarDataLoaders({
+    rootPath,
+    withErrorHandling,
+    overlays,
+  });
+  const {
+    loadProjectActions,
+    loadSectionFiles,
+    resolveReadmeFile,
+    resolveSectionLoadPaths,
+    projectActionsRef,
+    projectLoadingRef,
+    sectionFilesRef,
+    setPendingProjects,
+    setProjectActions,
+    setProjectLoading,
+    setSectionFiles,
+    pendingProjects,
+    projectActions,
+    projectLoading,
+    sectionFiles,
+    loadingSections,
+    loadedSections,
+  } = data;
 
-  const normalizedActivePath = React.useMemo(() => normalizePath(activeFilePath), [activeFilePath]);
+  const normalizedActivePath = React.useMemo(
+    () => normalizeSidebarPath(activeFilePath),
+    [activeFilePath]
+  );
   const isPathActive = React.useCallback(
     (candidatePath?: string | null) => {
       if (!candidatePath || !normalizedActivePath) return false;
-      return normalizePath(candidatePath) === normalizedActivePath;
+      return normalizeSidebarPath(candidatePath) === normalizedActivePath;
     },
     [normalizedActivePath]
   );
 
-  const sectionFilesRef = React.useRef<Record<string, MarkdownFile[]>>({});
-  const projectActionsRef = React.useRef<Record<string, MarkdownFile[]>>({});
-  const projectLoadingRef = React.useRef<Record<string, boolean>>({});
-  const lastRootRef = React.useRef<string | null>(null);
-  const preloadedRef = React.useRef(false);
-  const loadingSectionsRef = React.useRef<Set<string>>(new Set());
-  const workspaceGenerationRef = React.useRef(0);
-
-  const resolveReadmeFile = React.useCallback(async (folderPath: string): Promise<MarkdownFile> => {
-    const normalizedFolderPath = normalizePath(folderPath) ?? folderPath.replace(/\\/g, '/');
-    const markdownPath = `${normalizedFolderPath}/README.markdown`;
-    const mdPath = `${normalizedFolderPath}/README.md`;
-    const markdownExists = await withErrorHandling(async () => {
-      return safeInvoke<boolean>('check_file_exists', { filePath: markdownPath }, false);
-    }, 'Failed to resolve overview file', 'workspace-sidebar');
-    const filePath = markdownExists ? markdownPath : mdPath;
-
-    return {
-      id: filePath,
-      name: markdownExists ? 'README.markdown' : 'README.md',
-      path: filePath,
-      size: 0,
-      last_modified: Math.floor(Date.now() / 1000),
-      extension: markdownExists ? '.markdown' : '.md',
-    };
-  }, [withErrorHandling]);
-
-  React.useEffect(() => {
-    sectionFilesRef.current = sectionFiles;
-  }, [sectionFiles]);
-
-  React.useEffect(() => {
-    projectActionsRef.current = projectActions;
-  }, [projectActions]);
-
-  React.useEffect(() => {
-    projectLoadingRef.current = projectLoading;
-  }, [projectLoading]);
-
-  const syncHorizonReadme = React.useCallback(async (folderPath: string, files: MarkdownFile[]) => {
-    const folderName = getFolderName(folderPath);
-    const horizonType = HORIZON_FOLDER_TO_TYPE[folderName];
-    if (!horizonType) return;
-
-    const existingReadme = files.find((file) => /^README\.(md|markdown)$/i.test(file.name));
-    const readmePath = existingReadme?.path ?? `${folderPath}/README.md`;
-    const filteredFiles = files.filter((file) => !/^README\.(md|markdown)$/i.test(file.name));
-
-    const existingContent = await withErrorHandling(async () => {
-      return safeInvoke<string>('read_file', { path: readmePath }, null);
-    }, 'Failed to read horizon overview', 'workspace-sidebar');
-
-    if (typeof existingContent !== 'string') {
-      if (existingReadme) {
-        return;
-      }
-
-      const { content } = buildHorizonReadmeMarkdown({
-        horizon: horizonType,
-        referencePaths: filteredFiles.map((file) => norm(file.path) ?? file.path),
-      });
-
-      const writeResult = await withErrorHandling(async () => {
-        const result = await safeInvoke('save_file', { path: readmePath, content }, null);
-        if (!result) {
-          throw new Error('Failed to create horizon overview');
-        }
-        return result;
-      }, 'Failed to create horizon overview', 'workspace-sidebar');
-
-      if (!writeResult) {
-        return;
-      }
-
-      return;
-    }
-
-    try {
-      const { content, changed } = syncHorizonReadmeContent({
-        horizon: horizonType,
-        existingContent,
-        files: filteredFiles,
-      });
-      if (changed) {
-        const saveResult = await withErrorHandling(async () => {
-          const result = await safeInvoke('save_file', { path: readmePath, content }, null);
-          if (!result) {
-            throw new Error('Failed to save horizon overview');
-          }
-          return result;
-        }, 'Failed to save horizon overview', 'workspace-sidebar');
-
-        if (!saveResult) {
-          return;
-        }
-      }
-    } catch (error) {
-      console.error('Failed to sync horizon README', { folderPath, error });
-    }
-  }, [withErrorHandling]);
-
-  const updateProjectOverlay = React.useCallback(
-    (projectPath: string, patch: Partial<SidebarProjectMetadata>) => {
-      const normalizedKey = normalizePath(projectPath) ?? projectPath.replace(/\\/g, '/');
-      setProjectMetadata((prev) => ({
-        ...prev,
-        [normalizedKey]: {
-          ...prev[normalizedKey],
-          ...patch,
-        },
-      }));
-    },
-    []
-  );
-
-  const updateActionOverlay = React.useCallback(
-    (actionPath: string, patch: Partial<SidebarActionMetadata>) => {
-      const normalizedKey = normalizePath(actionPath) ?? actionPath.replace(/\\/g, '/');
-      setActionMetadata((prev) => ({
-        ...prev,
-        [normalizedKey]: {
-          ...prev[normalizedKey],
-          ...patch,
-        },
-      }));
-    },
-    []
-  );
-
-  const updateSectionFileOverlay = React.useCallback(
-    (filePath: string, patch: Partial<SidebarSectionFileMetadata>) => {
-      const normalizedKey = normalizePath(filePath) ?? filePath.replace(/\\/g, '/');
-      setSectionFileMetadata((prev) => ({
-        ...prev,
-        [normalizedKey]: {
-          ...prev[normalizedKey],
-          ...patch,
-        },
-      }));
-    },
-    []
-  );
-
-  const removeActionOverlay = React.useCallback((filePath: string) => {
-    const normalizedKey = normalizePath(filePath) ?? filePath.replace(/\\/g, '/');
-    setActionMetadata((prev) => {
-      const next = { ...prev };
-      delete next[normalizedKey];
-      return next;
-    });
-  }, []);
-
-  const removeProjectOverlay = React.useCallback((projectPath: string) => {
-    const normalizedKey = normalizePath(projectPath) ?? projectPath.replace(/\\/g, '/');
-    setProjectMetadata((prev) => {
-      const next = { ...prev };
-      delete next[normalizedKey];
-      return next;
-    });
-  }, []);
-
-  const removeSectionFileOverlay = React.useCallback((filePath: string) => {
-    const normalizedKey = normalizePath(filePath) ?? filePath.replace(/\\/g, '/');
-    setSectionFileMetadata((prev) => {
-      const next = { ...prev };
-      delete next[normalizedKey];
-      return next;
-    });
-  }, []);
-
-  const resolveSectionLoadPath = React.useCallback(
-    async (sectionId: string, root: string): Promise<string | null> => {
-      const section = GTD_SECTIONS.find((candidate) => candidate.id === sectionId);
-      if (!section || section.id === 'calendar' || section.id === 'projects') {
-        return null;
-      }
-
-      const candidatePaths = buildSectionPathCandidates(root, section);
-      if (candidatePaths.length <= 1) {
-        return candidatePaths[0] ?? null;
-      }
-
-      for (const candidatePath of candidatePaths) {
-        const exists = await withErrorHandling(
-          async () =>
-            safeInvoke<boolean>(
-              'check_directory_exists',
-              { path: candidatePath },
-              false
-            ),
-          'Failed to verify section directory'
-        );
-        if (exists) {
-          return candidatePath;
-        }
-      }
-
-      return candidatePaths[0] ?? null;
-    },
-    [withErrorHandling]
-  );
-
-  const resolveSectionLoadPaths = React.useCallback(
-    async (sectionIds: readonly string[], root: string): Promise<string[]> => {
-      const resolvedPaths = await Promise.all(
-        sectionIds.map((sectionId) => resolveSectionLoadPath(sectionId, root))
-      );
-
-      return [...new Set(resolvedPaths.filter((path): path is string => Boolean(path)))];
-    },
-    [resolveSectionLoadPath]
-  );
-
-  const resolveExistingSectionPath = React.useCallback(
-    async (sectionPath: string): Promise<string> => {
-      const normalizedPath = normalizePath(sectionPath) ?? sectionPath.replace(/\\/g, '/');
-      const sectionFromRoot = rootPath
-        ? GTD_SECTIONS.find((candidate) => {
-            if (candidate.id === 'calendar' || candidate.id === 'projects') {
-              return false;
-            }
-
-            return buildSectionPathCandidates(rootPath, candidate).some((candidatePath) =>
-              isUnder(norm(normalizedPath), norm(candidatePath))
-            );
-          })
-        : null;
-      const inferredContext = inferSectionContextFromPath(normalizedPath);
-      const section = sectionFromRoot ?? inferredContext?.section;
-      const candidateRoot = rootPath ?? inferredContext?.root;
-
-      if (!section || !candidateRoot) {
-        return normalizedPath;
-      }
-
-      const candidatePaths = buildSectionPathCandidates(candidateRoot, section);
-      const orderedPaths = candidatePaths.includes(normalizedPath)
-        ? [normalizedPath, ...candidatePaths.filter((candidate) => candidate !== normalizedPath)]
-        : candidatePaths;
-
-      for (const candidatePath of orderedPaths) {
-        const exists = await withErrorHandling(
-          async () =>
-            safeInvoke<boolean>(
-              'check_directory_exists',
-              { path: candidatePath },
-              false
-            ),
-          'Failed to verify section directory'
-        );
-        if (exists === true) {
-          return candidatePath;
-        }
-      }
-
-      return normalizedPath;
-    },
-    [rootPath, withErrorHandling]
-  );
-
-  const loadSectionFiles = React.useCallback(
-    async (sectionPath: string, force: boolean = false): Promise<MarkdownFile[]> => {
-      const generationAtStart = workspaceGenerationRef.current;
-      const requestedKey = normalizePath(sectionPath) ?? sectionPath.replace(/\\/g, '/');
-      const normalizedKey = await resolveExistingSectionPath(sectionPath);
-      const current = sectionFilesRef.current[normalizedKey] ?? sectionFilesRef.current[requestedKey];
-      if (!force && current) {
-        return current;
-      }
-
-      const directoryExists = await withErrorHandling(async () => {
-        return safeInvoke<boolean>(
-          'check_directory_exists',
-          { path: normalizedKey },
-          null
-        );
-      }, 'Failed to check section directory', 'workspace-sidebar');
-      if (directoryExists !== true) {
-        return current || [];
-      }
-
-      if (loadingSectionsRef.current.has(normalizedKey)) {
-        return current || [];
-      }
-
-      loadingSectionsRef.current.add(normalizedKey);
-      setLoadingSections((prev) => {
-        const next = new Set(prev);
-        next.add(normalizedKey);
-        return next;
-      });
-
-      try {
-        const files = await withErrorHandling(async () => {
-          const result = await safeInvoke<MarkdownFile[]>(
-            'list_markdown_files',
-            { path: normalizedKey },
-            null
-          );
-          if (result == null) {
-            throw new Error(`Failed to load section files for ${normalizedKey}`);
-          }
-          return result;
-        }, 'Failed to load section files', 'workspace-sidebar');
-        if (files === undefined || files === null) {
-          return current || [];
-        }
-        const sortedFiles = sortMarkdownFiles(files);
-
-        if (workspaceGenerationRef.current !== generationAtStart) {
-          return current || [];
-        }
-
-        setSectionFiles((prev) => {
-          const next = { ...prev };
-          if (normalizedKey !== requestedKey) {
-            delete next[requestedKey];
-          }
-          next[normalizedKey] = sortedFiles;
-          return next;
-        });
-        setLoadedSections((prev) => {
-          const next = new Set(prev);
-          if (normalizedKey !== requestedKey) {
-            next.delete(requestedKey);
-          }
-          next.add(normalizedKey);
-          return next;
-        });
-
-        if (workspaceGenerationRef.current !== generationAtStart) {
-          return sortedFiles;
-        }
-
-        await syncHorizonReadme(normalizedKey, sortedFiles);
-        return sortedFiles;
-      } catch {
-        return [];
-      } finally {
-        loadingSectionsRef.current.delete(normalizedKey);
-        setLoadingSections((prev) => {
-          const next = new Set(prev);
-          next.delete(normalizedKey);
-          return next;
-        });
-      }
-    },
-    [resolveExistingSectionPath, syncHorizonReadme, withErrorHandling]
-  );
-
-  const loadProjectActions = React.useCallback(async (projectPath: string) => {
-    const generationAtStart = workspaceGenerationRef.current;
-    const normalizedKey = normalizePath(projectPath) ?? projectPath.replace(/\\/g, '/');
-    if (projectLoadingRef.current[normalizedKey]) {
-      return;
-    }
-
-    projectLoadingRef.current = {
-      ...projectLoadingRef.current,
-      [normalizedKey]: true,
-    };
-    setProjectLoading((prev) => ({
-      ...prev,
-      [normalizedKey]: true,
-    }));
-
-    try {
-      let files = await withErrorHandling(async () => {
-        return safeInvoke<MarkdownFile[]>('list_project_actions', { projectPath: normalizedKey }, null);
-      }, 'Failed to load project actions', 'workspace-sidebar');
-      files = files ?? [];
-      if (files.length === 0) {
-        const all = await withErrorHandling(async () => {
-          const result = await safeInvoke<MarkdownFile[]>('list_markdown_files', { path: normalizedKey }, null);
-          if (result == null) {
-            throw new Error(`Failed to load project files for ${normalizedKey}`);
-          }
-          return result;
-        }, 'Failed to load project files', 'workspace-sidebar');
-        files = (all ?? []).filter((file) => !/^README\.(md|markdown)$/i.test(file.name));
-      }
-
-      if (workspaceGenerationRef.current !== generationAtStart) {
-        return;
-      }
-
-      flushSync(() => {
-        setProjectActions((prev) => ({
-          ...prev,
-          [normalizedKey]: files ?? [],
-        }));
-      });
-
-      const statusResults = await Promise.all(
-        (files ?? []).map(async (action) => {
-          try {
-            const content = await readFileText(action.path);
-            const parsedAction = parseActionMarkdown(content);
-            const normalizedActionPath = normalizePath(action.path) ?? action.path.replace(/\\/g, '/');
-            return {
-              path: normalizedActionPath,
-              status: parsedAction.status || 'in-progress',
-              due_date: parsedAction.dueDate || '',
-            };
-          } catch {
-            return {
-              path: normalizePath(action.path) ?? action.path.replace(/\\/g, '/'),
-              status: 'in-progress',
-              due_date: '',
-            };
-          }
-        })
-      );
-
-      if (workspaceGenerationRef.current !== generationAtStart) {
-        return;
-      }
-
-      const nextStatuses = Object.fromEntries(
-        statusResults.map((result) => [result.path, result.status])
-      );
-
-      flushSync(() => {
-        setActionStatuses((prev) => ({
-          ...prev,
-          ...nextStatuses,
-        }));
-        setProjectLoading((prev) => {
-          const next = { ...prev };
-          delete next[normalizedKey];
-          return next;
-        });
-      });
-      projectLoadingRef.current = Object.fromEntries(
-        Object.entries(projectLoadingRef.current).filter(([path]) => path !== normalizedKey)
-      );
-
-      setActionMetadata((prev) => {
-        const next = { ...prev };
-        statusResults.forEach(({ path, due_date }) => {
-          if (due_date) {
-            next[path] = {
-              ...next[path],
-              due_date,
-            };
-          } else if (next[path]) {
-            const { due_date: _ignored, ...rest } = next[path];
-            next[path] = rest;
-          }
-        });
-        return next;
-      });
-    } catch {
-      // Keep existing project action state when a refresh fails.
-    } finally {
-      if (workspaceGenerationRef.current === generationAtStart) {
-        projectLoadingRef.current = Object.fromEntries(
-          Object.entries(projectLoadingRef.current).filter(([path]) => path !== normalizedKey)
-        );
-        setProjectLoading((prev) => {
-          if (!(normalizedKey in prev)) {
-            return prev;
-          }
-          const next = { ...prev };
-          delete next[normalizedKey];
-          return next;
-        });
-      }
-    }
-  }, [withErrorHandling]);
-
-  React.useEffect(() => {
-    const pathToCheck = gtdSpace?.root_path;
-    const normalizedRoot = normalizePath(pathToCheck);
-    const normalizedCurrent = normalizePath(currentFolder);
-    const normalizedRootWithSlash = normalizedRoot?.endsWith('/')
-      ? normalizedRoot
-      : `${normalizedRoot ?? ''}/`;
-
-    if (
-      !normalizedRoot ||
-      !normalizedCurrent ||
-      !(
-        normalizedCurrent === normalizedRoot ||
-        normalizedCurrent.startsWith(normalizedRootWithSlash)
-      )
-    ) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const preload = async () => {
-      if (lastRootRef.current !== pathToCheck) {
-        workspaceGenerationRef.current += 1;
-        preloadedRef.current = false;
-        lastRootRef.current = pathToCheck;
-        setLoadedSections(new Set());
-        setSectionFiles({});
-        sectionFilesRef.current = {};
-        setProjectActions({});
-        projectActionsRef.current = {};
-        setProjectLoading({});
-        projectLoadingRef.current = {};
-        setProjectMetadata({});
-        setActionMetadata({});
-        setActionStatuses({});
-        setSectionFileMetadata({});
-        setPendingProjects([]);
-      }
-
-      const isGTD = await checkGTDSpace(pathToCheck);
-      if (!isGTD || cancelled) return;
-
-      if (!gtdSpace?.projects || gtdSpace.projects.length === 0) {
-        await loadProjects(pathToCheck);
-        if (cancelled) return;
-      }
-
-      if (!preloadedRef.current) {
-        preloadedRef.current = true;
-
-        const priorityPaths = await resolveSectionLoadPaths(
-          PRELOAD_PRIORITY_SECTION_IDS,
-          pathToCheck
-        );
-        const secondaryPaths = await resolveSectionLoadPaths(
-          PRELOAD_SECONDARY_SECTION_IDS,
-          pathToCheck
-        );
-
-        await Promise.allSettled(priorityPaths.map((path) => loadSectionFiles(path)));
-        if (cancelled) return;
-
-        await Promise.allSettled(secondaryPaths.map((path) => loadSectionFiles(path)));
-      }
-    };
-
-    void preload();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    checkGTDSpace,
+  useSidebarWorkspaceLifecycle({
     currentFolder,
-    gtdSpace?.projects,
-    gtdSpace?.root_path,
+    rootPath: workspaceRootPath,
+    projects: gtdSpace?.projects,
+    checkGTDSpace,
     loadProjects,
-    loadSectionFiles,
-    resolveSectionLoadPaths,
-  ]);
-
-  React.useEffect(() => {
-    const unsubscribeMetadata = onMetadataChange((event) => {
-      const { filePath, metadata, changedFields } = event;
-      const normalizedFilePath = normalizePath(filePath) ?? filePath.replace(/\\/g, '/');
-
-      if (
-        normalizedFilePath.includes('/Projects/') &&
-        /\/README\.(md|markdown)$/i.test(normalizedFilePath)
-      ) {
-        const projectPath = normalizedFilePath.substring(0, normalizedFilePath.lastIndexOf('/'));
-
-        if (changedFields?.status || changedFields?.projectStatus) {
-          const nextStatus = metadata.projectStatus || metadata.status;
-          if (nextStatus) {
-            updateProjectOverlay(projectPath, { status: String(nextStatus) });
-          } else {
-            updateProjectOverlay(projectPath, { status: '' });
-          }
-        }
-
-        if (changedFields?.due_date || changedFields?.dueDate || changedFields?.datetime) {
-          const nextDue =
-            (metadata as { due_date?: string; dueDate?: string }).due_date ||
-            (metadata as { due_date?: string; dueDate?: string }).dueDate;
-          if (typeof nextDue === 'string') {
-            updateProjectOverlay(projectPath, { due_date: nextDue });
-          } else {
-            updateProjectOverlay(projectPath, { due_date: undefined });
-          }
-        }
-      }
-
-      if (
-        normalizedFilePath.includes('/Projects/') &&
-        !/\/README\.(md|markdown)$/i.test(normalizedFilePath) &&
-        /\.(md|markdown)$/i.test(normalizedFilePath)
-      ) {
-        if (changedFields?.status && metadata.status) {
-          setActionStatuses((prev) => ({
-            ...prev,
-            [normalizedFilePath]: String(metadata.status),
-          }));
-          updateActionOverlay(normalizedFilePath, { status: String(metadata.status) });
-        }
-
-        if (changedFields?.due_date || changedFields?.dueDate || changedFields?.datetime) {
-          const nextDue =
-            (metadata as { due_date?: string; dueDate?: string }).due_date ||
-            (metadata as { due_date?: string; dueDate?: string }).dueDate;
-          updateActionOverlay(normalizedFilePath, {
-            due_date: typeof nextDue === 'string' ? nextDue : undefined,
-          });
-        }
-      }
-
-      const sectionPaths = getCombinedSectionPathVariants(RELOAD_SECTION_IDS);
-
-      for (const sectionPath of sectionPaths) {
-        if (normalizedFilePath.includes(sectionPath)) {
-          const folderPath = normalizedFilePath.substring(0, normalizedFilePath.lastIndexOf('/'));
-          void loadSectionFiles(folderPath, true);
-          break;
-        }
-      }
-    });
-
-    const unsubscribeChanged = onContentChange((event) => {
-      const { filePath, metadata, changedFields } = event;
-      const normalizedFilePath = normalizePath(filePath) ?? filePath.replace(/\\/g, '/');
-
-      if (
-        normalizedFilePath.includes('/Projects/') &&
-        /\/README\.(md|markdown)$/i.test(normalizedFilePath)
-      ) {
-        const projectPath = normalizedFilePath.substring(0, normalizedFilePath.lastIndexOf('/'));
-        if (changedFields?.dueDate || changedFields?.due_date || changedFields?.datetime) {
-          const nextDue =
-            (metadata as { due_date?: string; dueDate?: string }).dueDate ||
-            (metadata as { due_date?: string; dueDate?: string }).due_date;
-          if (typeof nextDue === 'string') {
-            updateProjectOverlay(projectPath, { due_date: nextDue });
-          } else {
-            updateProjectOverlay(projectPath, { due_date: undefined });
-          }
-        }
-      }
-    });
-
-    const unsubscribeSaved = onContentSaved(async (event) => {
-      const { filePath, metadata } = event;
-      const normalizedFilePath = normalizePath(filePath) ?? filePath.replace(/\\/g, '/');
-
-      if (
-        normalizedFilePath.includes('/Projects/') &&
-        /\/README\.(md|markdown)$/i.test(normalizedFilePath)
-      ) {
-        const projectPath = normalizedFilePath.substring(0, normalizedFilePath.lastIndexOf('/'));
-        const nextTitle = metadata.title;
-
-        if (nextTitle) {
-          const currentProjectName = projectPath.split('/').pop();
-
-          if (currentProjectName && currentProjectName !== nextTitle) {
-            await withErrorHandling(async () => {
-              const newProjectPath = await safeInvoke<string>(
-                'rename_gtd_project',
-                { oldProjectPath: projectPath, newProjectName: nextTitle },
-                null
-              );
-              if (!newProjectPath || typeof newProjectPath !== 'string') {
-                throw new Error('rename_gtd_project failed');
-              }
-
-              const normalizedNewProjectPath = normalizePath(newProjectPath) ?? newProjectPath;
-              updateProjectOverlay(projectPath, {
-                title: String(nextTitle),
-                currentPath: normalizedNewProjectPath,
-              });
-              updateProjectOverlay(normalizedNewProjectPath, {
-                title: String(nextTitle),
-                currentPath: normalizedNewProjectPath,
-              });
-
-              setExpandedProjects((prev) =>
-                prev.map((path) => (path === projectPath ? normalizedNewProjectPath : path))
-              );
-              setProjectActions((prev) =>
-                prev[projectPath]
-                  ? {
-                      ...prev,
-                    }
-                  : prev
-              );
-
-              if (gtdSpace?.root_path) {
-                await loadProjects(gtdSpace.root_path);
-                removeProjectOverlay(projectPath);
-                setProjectActions((prev) => {
-                  const next = { ...prev };
-                  delete next[projectPath];
-                  return next;
-                });
-              }
-
-              window.dispatchEvent(
-                new CustomEvent('project-renamed', {
-                  detail: {
-                    oldPath: projectPath,
-                    newPath: normalizedNewProjectPath,
-                    newName: nextTitle,
-                  },
-                })
-              );
-            }, 'Failed to rename project', 'workspace-sidebar');
-          }
-        }
-
-        const nextDue =
-          (metadata as { due_date?: string; dueDate?: string }).due_date ||
-          (metadata as { due_date?: string; dueDate?: string }).dueDate;
-        if (typeof nextDue === 'string') {
-          updateProjectOverlay(projectPath, { due_date: nextDue });
-        } else {
-          updateProjectOverlay(projectPath, { due_date: undefined });
-        }
-
-        if (gtdSpace?.root_path) {
-          await loadProjects(gtdSpace.root_path);
-        }
-      }
-
-      if (
-        normalizedFilePath.includes('/Projects/') &&
-        !/\/README\.(md|markdown)$/i.test(normalizedFilePath) &&
-        /\.(md|markdown)$/i.test(normalizedFilePath)
-      ) {
-        const nextTitle = metadata.title;
-        if (nextTitle) {
-          const currentActionName = normalizedFilePath
-            .split('/')
-            .pop()
-            ?.replace(/\.(md|markdown)$/i, '');
-          if (currentActionName && currentActionName !== nextTitle) {
-            await withErrorHandling(async () => {
-              const newActionPath = await safeInvoke<string>(
-                'rename_gtd_action',
-                { oldActionPath: normalizedFilePath, newActionName: nextTitle },
-                null
-              );
-              if (!newActionPath || typeof newActionPath !== 'string') {
-                throw new Error('rename_gtd_action failed');
-              }
-
-              const normalizedNewActionPath = normalizePath(newActionPath) ?? newActionPath;
-              updateActionOverlay(normalizedFilePath, {
-                title: String(nextTitle),
-                currentPath: normalizedNewActionPath,
-              });
-              updateActionOverlay(normalizedNewActionPath, {
-                title: String(nextTitle),
-                currentPath: normalizedNewActionPath,
-              });
-
-              const projectPath = normalizedFilePath.substring(0, normalizedFilePath.lastIndexOf('/'));
-              await loadProjectActions(projectPath);
-              removeActionOverlay(normalizedFilePath);
-
-              window.dispatchEvent(
-                new CustomEvent('action-renamed', {
-                  detail: {
-                    oldPath: normalizedFilePath,
-                    newPath: normalizedNewActionPath,
-                    newName: nextTitle,
-                  },
-                })
-              );
-              window.dispatchEvent(
-                new CustomEvent('file-renamed', {
-                  detail: {
-                    oldPath: normalizedFilePath,
-                    newPath: normalizedNewActionPath,
-                  },
-                })
-              );
-            }, 'Failed to rename action', 'workspace-sidebar');
-          }
-        }
-      }
-
-      const sectionPaths = getCombinedSectionPathVariants(RELOAD_SECTION_IDS);
-
-      for (const sectionPath of sectionPaths) {
-        if (
-          normalizedFilePath.includes(sectionPath) &&
-          /\.(md|markdown)$/i.test(normalizedFilePath)
-        ) {
-          const nextTitle = metadata.title;
-
-          if (nextTitle) {
-            const currentFileName = normalizedFilePath
-              .split('/')
-              .pop()
-              ?.replace(/\.(md|markdown)$/i, '');
-            if (
-              currentFileName &&
-              currentFileName.toLowerCase() !== 'readme' &&
-              currentFileName !== nextTitle
-            ) {
-              await withErrorHandling(async () => {
-                const renameResult = await safeInvoke<FileOperationResult>(
-                  'rename_file',
-                  { oldPath: normalizedFilePath, newName: nextTitle },
-                  null
-                );
-                if (!renameResult?.success || !renameResult.path) {
-                  throw new Error(renameResult?.message || 'rename_file failed');
-                }
-                const newFilePath = renameResult.path;
-
-                const normalizedNewFilePath = normalizePath(newFilePath) ?? newFilePath;
-                updateSectionFileOverlay(normalizedFilePath, {
-                  title: String(nextTitle),
-                  currentPath: normalizedNewFilePath,
-                });
-                updateSectionFileOverlay(normalizedNewFilePath, {
-                  title: String(nextTitle),
-                  currentPath: normalizedNewFilePath,
-                });
-
-                const folderPath = normalizedFilePath.substring(0, normalizedFilePath.lastIndexOf('/'));
-                await loadSectionFiles(folderPath, true);
-                removeSectionFileOverlay(normalizedFilePath);
-
-                window.dispatchEvent(
-                  new CustomEvent('section-file-renamed', {
-                    detail: {
-                      oldPath: normalizedFilePath,
-                      newPath: normalizedNewFilePath,
-                      newName: nextTitle,
-                    },
-                  })
-                );
-                window.dispatchEvent(
-                  new CustomEvent('file-renamed', {
-                    detail: {
-                      oldPath: normalizedFilePath,
-                      newPath: normalizedNewFilePath,
-                    },
-                  })
-                );
-              }, 'Failed to rename file', 'workspace-sidebar');
-            }
-          }
-          break;
-        }
-      }
-    });
-
-    const handleProjectCreated = async (event: Event) => {
-      const customEvent = event as CustomEvent<{ projectPath?: string; projectName?: string }>;
-      const { projectPath, projectName } = customEvent.detail ?? {};
-
-      if (projectPath && projectName) {
-        const optimistic: GTDProject = {
-          name: projectName,
-          description: '',
-          dueDate: undefined,
-          status: 'in-progress',
-          path: projectPath,
-          createdDateTime: new Date().toISOString(),
-          action_count: 0,
-        };
-
-        setPendingProjects((prev) =>
-          prev.some(
-            (project) => (norm(project.path) ?? project.path) === (norm(optimistic.path) ?? optimistic.path)
-          )
-            ? prev
-            : [...prev, optimistic]
-        );
-      }
-
-      if (gtdSpace?.root_path) {
-        const projects = await loadProjects(gtdSpace.root_path);
-        setPendingProjects((prev) =>
-          prev.filter(
-            (project) =>
-              !projects.some(
-                (loaded) => (norm(loaded.path) ?? loaded.path) === (norm(project.path) ?? project.path)
-              )
-          )
-        );
-      }
-    };
-
-    const handleActionCreated = async (event: Event) => {
-      const customEvent = event as CustomEvent<{ projectPath?: string }>;
-      const projectPath = customEvent.detail?.projectPath;
-      if (!projectPath) return;
-
-      await loadProjectActions(projectPath);
-      if (gtdSpace?.root_path) {
-        await loadProjects(gtdSpace.root_path);
-      }
-    };
-
-    window.addEventListener('gtd-project-created', handleProjectCreated as EventListener);
-    window.addEventListener('gtd-action-created', handleActionCreated as EventListener);
-
-    return () => {
-      unsubscribeMetadata();
-      unsubscribeChanged();
-      unsubscribeSaved();
-      window.removeEventListener('gtd-project-created', handleProjectCreated as EventListener);
-      window.removeEventListener('gtd-action-created', handleActionCreated as EventListener);
-    };
-  }, [
-    gtdSpace?.root_path,
     loadProjectActions,
-    loadProjects,
+    resolveSectionLoadPaths,
     loadSectionFiles,
-    removeActionOverlay,
-    removeProjectOverlay,
-    removeSectionFileOverlay,
-    updateActionOverlay,
-    updateProjectOverlay,
-    updateSectionFileOverlay,
+    data,
+    overlays,
+  });
+
+  useSidebarEventBridge({
+    rootPath: workspaceRootPath,
     withErrorHandling,
-  ]);
-
-  React.useEffect(() => {
-    if (!gtdSpace?.projects || gtdSpace.projects.length === 0) return;
-
-    const missingProjects = gtdSpace.projects.filter((project) => {
-      const normalizedKey = normalizePath(project.path) ?? project.path.replace(/\\/g, '/');
-      return !projectActions[normalizedKey] && !projectLoading[normalizedKey];
-    });
-    if (missingProjects.length === 0) return;
-
-    void Promise.all(missingProjects.map((project) => loadProjectActions(project.path)));
-  }, [gtdSpace?.projects, loadProjectActions, projectActions, projectLoading]);
-
-  const toggleSection = React.useCallback((sectionId: string) => {
-    setExpandedSections((prev) =>
-      prev.includes(sectionId) ? prev.filter((id) => id !== sectionId) : [...prev, sectionId]
-    );
-  }, []);
-
-  const toggleCompletedActions = React.useCallback((projectPath: string) => {
-    const normalizedProjectPath = normalizePath(projectPath) ?? projectPath.replace(/\\/g, '/');
-    setExpandedCompletedActions((prev) => {
-      const next = new Set(prev);
-      if (next.has(normalizedProjectPath)) {
-        next.delete(normalizedProjectPath);
-      } else {
-        next.add(normalizedProjectPath);
-      }
-      return next;
-    });
-  }, []);
+    loadProjects,
+    loadProjectActions,
+    loadSectionFiles,
+    overlays,
+    ui,
+    data,
+  });
 
   const handleProjectClick = React.useCallback(
     async (project: GTDProject) => {
-      setSelectedProject(project);
-      const normalizedProjectPath = normalizePath(project.path) ?? project.path.replace(/\\/g, '/');
+      ui.setSelectedProject(project);
+      const normalizedProjectPath =
+        normalizeSidebarPath(project.path) ?? project.path.replace(/\\/g, '/');
       if (
         !projectActionsRef.current[normalizedProjectPath] &&
         !projectLoadingRef.current[normalizedProjectPath]
@@ -1186,19 +207,22 @@ export function useGTDWorkspaceSidebar({
 
       onFileSelect(await resolveReadmeFile(project.path));
     },
-    [loadProjectActions, onFileSelect, resolveReadmeFile]
+    [loadProjectActions, onFileSelect, projectActionsRef, projectLoadingRef, resolveReadmeFile, ui]
   );
 
   const toggleProjectExpand = React.useCallback(
     async (project: GTDProject) => {
-      const normalizedProjectPath = normalizePath(project.path) ?? project.path.replace(/\\/g, '/');
-      const isExpanded = expandedProjects.includes(normalizedProjectPath);
+      const normalizedProjectPath =
+        normalizeSidebarPath(project.path) ?? project.path.replace(/\\/g, '/');
+      const isExpanded = ui.expandedProjects.includes(normalizedProjectPath);
       if (isExpanded) {
-        setExpandedProjects((prev) => prev.filter((path) => path !== normalizedProjectPath));
+        ui.setExpandedProjects((prev) =>
+          prev.filter((path) => path !== normalizedProjectPath)
+        );
         return;
       }
 
-      setExpandedProjects((prev) => [...prev, normalizedProjectPath]);
+      ui.setExpandedProjects((prev) => [...prev, normalizedProjectPath]);
       if (
         !projectActionsRef.current[normalizedProjectPath] &&
         !projectLoadingRef.current[normalizedProjectPath]
@@ -1206,7 +230,7 @@ export function useGTDWorkspaceSidebar({
         await loadProjectActions(project.path);
       }
     },
-    [expandedProjects, loadProjectActions]
+    [loadProjectActions, projectActionsRef, projectLoadingRef, ui]
   );
 
   const openHorizonReadme = React.useCallback(
@@ -1224,23 +248,24 @@ export function useGTDWorkspaceSidebar({
       if (!section) return;
 
       if (section.id === 'habits') {
-        setShowHabitDialog(true);
+        ui.setShowHabitDialog(true);
         return;
       }
 
-      const path = buildSectionPath(rootPath, section.path);
+      const defaultPath = buildSectionPath(rootPath, section.path);
       const candidatePaths = buildSectionPathCandidates(rootPath, section);
       const resolvedPath =
-        candidatePaths.find((candidate) => sectionFilesRef.current[candidate]) ?? path;
-      setPageDialogDirectory({
+        candidatePaths.find((candidate) => sectionFilesRef.current[candidate]) ?? defaultPath;
+
+      ui.setPageDialogDirectory({
         path: resolvedPath,
         name: section.name,
         sectionId: section.id,
         spacePath: rootPath ?? '',
       });
-      setShowPageDialog(true);
+      ui.setShowPageDialog(true);
     },
-    [rootPath]
+    [rootPath, sectionFilesRef, ui]
   );
 
   const handleSelectFolder = React.useCallback(async () => {
@@ -1260,11 +285,7 @@ export function useGTDWorkspaceSidebar({
   const handleOpenFolderInExplorer = React.useCallback(async () => {
     if (!currentFolder) return;
     await withErrorHandling(async () => {
-      const result = await safeInvoke(
-        'open_folder_in_explorer',
-        { path: currentFolder },
-        null
-      );
+      const result = await safeInvoke('open_folder_in_explorer', { path: currentFolder }, null);
       if (result == null) {
         throw new Error('Failed to open folder in explorer');
       }
@@ -1272,15 +293,18 @@ export function useGTDWorkspaceSidebar({
     }, 'Failed to open folder in explorer');
   }, [currentFolder, withErrorHandling]);
 
-  const handleOpenFileLocation = React.useCallback(async (path: string) => {
-    await withErrorHandling(async () => {
-      const result = await safeInvoke('open_file_location', { filePath: path }, null);
-      if (result == null) {
-        throw new Error('Failed to open file location');
-      }
-      return result;
-    }, 'Failed to open file location');
-  }, [withErrorHandling]);
+  const handleOpenFileLocation = React.useCallback(
+    async (path: string) => {
+      await withErrorHandling(async () => {
+        const result = await safeInvoke('open_file_location', { filePath: path }, null);
+        if (result == null) {
+          throw new Error('Failed to open file location');
+        }
+        return result;
+      }, 'Failed to open file location');
+    },
+    [withErrorHandling]
+  );
 
   const handleRefresh = React.useCallback(async () => {
     onRefresh?.();
@@ -1290,143 +314,179 @@ export function useGTDWorkspaceSidebar({
     await loadProjects(rootPath);
 
     const nonProjectSectionPaths = await resolveSectionLoadPaths(
-      GTD_SECTIONS.filter((section) => section.id !== 'calendar' && section.id !== 'projects').map(
-        (section) => section.id
-      ),
+      GTD_SECTIONS.filter(
+        (section) => section.id !== 'calendar' && section.id !== 'projects'
+      ).map((section) => section.id),
       rootPath
     );
 
-    await Promise.all([...new Set(nonProjectSectionPaths)].map((path) => loadSectionFiles(path, true)));
-    await Promise.all(Object.keys(projectActionsRef.current).map((path) => loadProjectActions(path)));
+    await Promise.all(
+      [...new Set(nonProjectSectionPaths)].map((path) => loadSectionFiles(path, true))
+    );
+    await Promise.all(
+      Object.keys(projectActionsRef.current).map((path) => loadProjectActions(path))
+    );
   }, [
-    loadProjectActions,
     loadProjects,
+    loadProjectActions,
     loadSectionFiles,
     onRefresh,
+    projectActionsRef,
     resolveSectionLoadPaths,
     rootPath,
   ]);
 
   const handleDelete = React.useCallback(async () => {
+    const deleteItem = ui.deleteItem;
     if (!deleteItem) return;
 
-    const deleted = await withErrorHandling(async () => {
-      const normalizedDeletePath = normalizePath(deleteItem.path) ?? deleteItem.path.replace(/\\/g, '/');
+    const deleted = await withErrorHandling(
+      async () => {
+        const normalizedDeletePath =
+          normalizeSidebarPath(deleteItem.path) ?? deleteItem.path.replace(/\\/g, '/');
 
-      if (deleteItem.type === 'project') {
-        const result = await safeInvoke<{
-          success: boolean;
-          path?: string | null;
-          message?: string | null;
-        }>('delete_folder', { path: normalizedDeletePath }, { success: false, message: 'Failed to delete folder' });
+        if (deleteItem.type === 'project') {
+          const result = await safeInvoke<{
+            success: boolean;
+            path?: string | null;
+            message?: string | null;
+          }>(
+            'delete_folder',
+            { path: normalizedDeletePath },
+            { success: false, message: 'Failed to delete folder' }
+          );
 
-        if (!result?.success) {
-          throw new Error(result?.message || 'Failed to delete project');
-        }
-
-        setPendingProjects((prev) =>
-          prev.filter(
-            (project) => (norm(project.path) ?? project.path) !== normalizedDeletePath
-          )
-        );
-        setExpandedProjects((prev) => prev.filter((path) => path !== normalizedDeletePath));
-        setProjectActions((prev) => {
-          const next = { ...prev };
-          delete next[normalizedDeletePath];
-          return next;
-        });
-        setProjectLoading((prev) => {
-          if (!(normalizedDeletePath in prev)) {
-            return prev;
+          if (!result?.success) {
+            throw new Error(result?.message || 'Failed to delete project');
           }
-          const next = { ...prev };
-          delete next[normalizedDeletePath];
-          return next;
-        });
-        projectLoadingRef.current = Object.fromEntries(
-          Object.entries(projectLoadingRef.current).filter(([path]) => path !== normalizedDeletePath)
-        );
-        removeProjectOverlay(normalizedDeletePath);
-        window.dispatchEvent(
-          new CustomEvent('file-deleted', {
-            detail: { path: normalizedDeletePath },
-          })
-        );
 
-        if (gtdSpace?.root_path) {
-          await loadProjects(gtdSpace.root_path);
-        }
-      } else {
-        const result = await safeInvoke<{
-          success: boolean;
-          path?: string | null;
-          message?: string | null;
-        }>('delete_file', { path: normalizedDeletePath }, { success: false, message: 'Failed to delete file' });
-
-        if (!result?.success) {
-          throw new Error(result?.message || 'Failed to delete file');
-        }
-
-        if (deleteItem.type === 'action') {
-          setActionStatuses((prev) => {
+          setPendingProjects((prev) =>
+            prev.filter(
+              (project) => (norm(project.path) ?? project.path) !== normalizedDeletePath
+            )
+          );
+          ui.setExpandedProjects((prev) =>
+            prev.filter((path) => path !== normalizedDeletePath)
+          );
+          setProjectActions((prev) => {
             const next = { ...prev };
             delete next[normalizedDeletePath];
             return next;
           });
-          removeActionOverlay(normalizedDeletePath);
+          setProjectLoading((prev) => {
+            if (!(normalizedDeletePath in prev)) {
+              return prev;
+            }
+            const next = { ...prev };
+            delete next[normalizedDeletePath];
+            projectLoadingRef.current = next;
+            return next;
+          });
+          overlays.removeProjectOverlay(normalizedDeletePath);
+          window.dispatchEvent(
+            new CustomEvent('file-deleted', {
+              detail: { path: normalizedDeletePath },
+            })
+          );
 
-          const projectPath = normalizedDeletePath.substring(0, normalizedDeletePath.lastIndexOf('/'));
-          setProjectActions((prev) => ({
-            ...prev,
-            [projectPath]:
-              prev[projectPath]?.filter((action) => action.path !== normalizedDeletePath) || [],
-          }));
-          await loadProjectActions(projectPath);
+          if (workspaceRootPath) {
+            await loadProjects(workspaceRootPath);
+          }
         } else {
-          removeSectionFileOverlay(normalizedDeletePath);
-          const sectionPath = normalizedDeletePath.substring(0, normalizedDeletePath.lastIndexOf('/'));
-          setSectionFiles((prev) => ({
-            ...prev,
-            [sectionPath]:
-              prev[sectionPath]?.filter((file) => file.path !== normalizedDeletePath) || [],
-          }));
-          await loadSectionFiles(sectionPath, true);
+          const result = await safeInvoke<{
+            success: boolean;
+            path?: string | null;
+            message?: string | null;
+          }>(
+            'delete_file',
+            { path: normalizedDeletePath },
+            { success: false, message: 'Failed to delete file' }
+          );
+
+          if (!result?.success) {
+            throw new Error(result?.message || 'Failed to delete file');
+          }
+
+          if (deleteItem.type === 'action') {
+            overlays.setActionStatuses((prev) => {
+              const next = { ...prev };
+              delete next[normalizedDeletePath];
+              return next;
+            });
+            overlays.removeActionOverlay(normalizedDeletePath);
+
+            const projectPath = normalizedDeletePath.substring(
+              0,
+              normalizedDeletePath.lastIndexOf('/')
+            );
+            setProjectActions((prev) => ({
+              ...prev,
+              [projectPath]:
+                prev[projectPath]?.filter(
+                  (action) => action.path !== normalizedDeletePath
+                ) || [],
+            }));
+            await loadProjectActions(projectPath);
+          } else {
+            overlays.removeSectionFileOverlay(normalizedDeletePath);
+            const sectionPath = normalizedDeletePath.substring(
+              0,
+              normalizedDeletePath.lastIndexOf('/')
+            );
+            setSectionFiles((prev) => ({
+              ...prev,
+              [sectionPath]:
+                prev[sectionPath]?.filter(
+                  (file) => file.path !== normalizedDeletePath
+                ) || [],
+            }));
+            await loadSectionFiles(sectionPath, true);
+          }
+
+          window.dispatchEvent(
+            new CustomEvent('file-deleted', {
+              detail: { path: normalizedDeletePath },
+            })
+          );
         }
 
-        window.dispatchEvent(
-          new CustomEvent('file-deleted', {
-            detail: { path: normalizedDeletePath },
-          })
-        );
-      }
-
-      return true;
-    }, deleteItem.type === 'project' ? 'Failed to delete project' : 'Failed to delete file', 'workspace-sidebar');
+        return true;
+      },
+      deleteItem.type === 'project'
+        ? 'Failed to delete project'
+        : 'Failed to delete file',
+      'workspace-sidebar'
+    );
 
     if (deleted) {
-      setDeleteItem(null);
+      ui.setDeleteItem(null);
     }
   }, [
-    deleteItem,
-    gtdSpace?.root_path,
     loadProjectActions,
     loadProjects,
     loadSectionFiles,
-    removeActionOverlay,
-    removeProjectOverlay,
-    removeSectionFileOverlay,
+    overlays,
+    projectLoadingRef,
+    setPendingProjects,
+    setProjectActions,
+    setProjectLoading,
+    setSectionFiles,
+    ui,
     withErrorHandling,
+    workspaceRootPath,
   ]);
 
   const handlePageCreated = React.useCallback(
     (filePath: string) => {
+      const pageDialogDirectory = ui.pageDialogDirectory;
       if (!pageDialogDirectory) return;
       const normalizedDirectoryPath =
-        normalizePath(pageDialogDirectory.path) ?? pageDialogDirectory.path.replace(/\\/g, '/');
+        normalizeSidebarPath(pageDialogDirectory.path) ??
+        pageDialogDirectory.path.replace(/\\/g, '/');
 
       const newFile: MarkdownFile = {
         id: filePath,
-        name: getFolderName(normalizePath(filePath) ?? filePath),
+        name: getFolderName(normalizeSidebarPath(filePath) ?? filePath),
         path: filePath,
         size: 0,
         last_modified: Math.floor(Date.now() / 1000),
@@ -1443,7 +503,7 @@ export function useGTDWorkspaceSidebar({
         });
       });
 
-      setExpandedSections((prev) =>
+      ui.setExpandedSections((prev) =>
         prev.includes(pageDialogDirectory.sectionId)
           ? prev
           : [...prev, pageDialogDirectory.sectionId]
@@ -1452,7 +512,7 @@ export function useGTDWorkspaceSidebar({
       onFileSelect(newFile);
       void loadSectionFiles(pageDialogDirectory.path, true);
     },
-    [loadSectionFiles, onFileSelect, pageDialogDirectory]
+    [loadSectionFiles, onFileSelect, setSectionFiles, ui]
   );
 
   const handleHabitCreated = React.useCallback(
@@ -1460,11 +520,12 @@ export function useGTDWorkspaceSidebar({
       const habitsSection = GTD_SECTIONS.find((section) => section.id === 'habits');
       if (!habitsSection || !rootPath) return;
 
-      const habitsPath = buildSectionPath(rootPath, habitsSection.path);
-      const normalizedHabitsPath = normalizePath(habitsPath) ?? habitsPath.replace(/\\/g, '/');
+      const habitsPath = buildCanonicalSectionPath(rootPath, habitsSection.path);
+      const normalizedHabitsPath =
+        normalizeSidebarPath(habitsPath) ?? habitsPath.replace(/\\/g, '/');
       const newFile: MarkdownFile = {
         id: habitPath,
-        name: getFolderName(normalizePath(habitPath) ?? habitPath),
+        name: getFolderName(normalizeSidebarPath(habitPath) ?? habitPath),
         path: habitPath,
         size: 0,
         last_modified: Math.floor(Date.now() / 1000),
@@ -1479,11 +540,11 @@ export function useGTDWorkspaceSidebar({
         };
       });
 
-      setExpandedSections((prev) => (prev.includes('habits') ? prev : [...prev, 'habits']));
+      ui.setExpandedSections((prev) => (prev.includes('habits') ? prev : [...prev, 'habits']));
       onFileSelect(newFile);
       void loadSectionFiles(habitsPath, true);
     },
-    [loadSectionFiles, onFileSelect, rootPath]
+    [loadSectionFiles, onFileSelect, rootPath, setSectionFiles, ui]
   );
 
   const filteredProjects = React.useMemo(() => {
@@ -1500,90 +561,94 @@ export function useGTDWorkspaceSidebar({
       }
     });
 
-    if (!searchQuery) return merged;
+    if (!ui.searchQuery) return merged;
 
-    const query = searchQuery.toLowerCase();
+    const query = ui.searchQuery.toLowerCase();
     return merged.filter(
       (project) =>
         project.name.toLowerCase().includes(query) ||
         (project.description || '').toLowerCase().includes(query)
     );
-  }, [gtdSpace?.projects, pendingProjects, searchQuery]);
+  }, [gtdSpace?.projects, pendingProjects, ui.searchQuery]);
 
   const searchResults = React.useMemo(
     () =>
       buildSidebarSearchResults({
-        searchQuery,
+        searchQuery: ui.searchQuery,
         projects: gtdSpace?.projects || [],
         projectActions,
         sectionFiles,
         sections: GTD_SECTIONS,
         rootPath,
-        projectMetadata,
-        actionMetadata,
-        actionStatuses,
-        sectionFileMetadata,
+        projectMetadata: overlays.projectMetadata,
+        actionMetadata: overlays.actionMetadata,
+        actionStatuses: overlays.actionStatuses,
+        sectionFileMetadata: overlays.sectionFileMetadata,
       }),
     [
-      actionMetadata,
-      actionStatuses,
       gtdSpace?.projects,
+      overlays.actionMetadata,
+      overlays.actionStatuses,
+      overlays.projectMetadata,
+      overlays.sectionFileMetadata,
       projectActions,
-      projectMetadata,
       rootPath,
-      searchQuery,
-      sectionFileMetadata,
       sectionFiles,
+      ui.searchQuery,
     ]
   );
 
-  const { active: activeProjects, completed: completedProjects, cancelled: cancelledProjects } = React.useMemo(
+  const {
+    active: activeProjects,
+    completed: completedProjects,
+    cancelled: cancelledProjects,
+  } = React.useMemo(
     () =>
       partitionProjectsByCompletion({
         projects: filteredProjects,
-        projectMetadata,
+        projectMetadata: overlays.projectMetadata,
       }),
-    [filteredProjects, projectMetadata]
+    [filteredProjects, overlays.projectMetadata]
   );
 
   return {
     gtdSpace,
     isLoading,
     rootPath,
-    showProjectDialog,
-    setShowProjectDialog,
-    showActionDialog,
-    setShowActionDialog,
-    selectedProject,
-    setSelectedProject,
-    expandedSections,
-    expandedProjects,
-    completedProjectsExpanded,
-    setCompletedProjectsExpanded,
-    cancelledProjectsExpanded,
-    setCancelledProjectsExpanded,
-    expandedCompletedActions,
+    showProjectDialog: ui.showProjectDialog,
+    setShowProjectDialog: ui.setShowProjectDialog,
+    showActionDialog: ui.showActionDialog,
+    setShowActionDialog: ui.setShowActionDialog,
+    selectedProject: ui.selectedProject,
+    setSelectedProject: ui.setSelectedProject,
+    expandedSections: ui.expandedSections,
+    expandedProjects: ui.expandedProjects,
+    completedProjectsExpanded: ui.completedProjectsExpanded,
+    setCompletedProjectsExpanded: ui.setCompletedProjectsExpanded,
+    cancelledProjectsExpanded: ui.cancelledProjectsExpanded,
+    setCancelledProjectsExpanded: ui.setCancelledProjectsExpanded,
+    expandedCompletedActions: ui.expandedCompletedActions,
     projectActions,
     projectLoading,
-    actionStatuses,
-    searchQuery,
-    setSearchQuery,
-    showSearch,
-    setShowSearch,
-    showPageDialog,
-    setShowPageDialog,
-    pageDialogDirectory,
-    setPageDialogDirectory,
-    showHabitDialog,
-    setShowHabitDialog,
+    actionStatuses: overlays.actionStatuses,
+    searchQuery: ui.searchQuery,
+    setSearchQuery: ui.setSearchQuery,
+    showSearch: ui.showSearch,
+    setShowSearch: ui.setShowSearch,
+    showPageDialog: ui.showPageDialog,
+    setShowPageDialog: ui.setShowPageDialog,
+    pageDialogDirectory: ui.pageDialogDirectory,
+    setPageDialogDirectory: ui.setPageDialogDirectory,
+    showHabitDialog: ui.showHabitDialog,
+    setShowHabitDialog: ui.setShowHabitDialog,
     sectionFiles,
     loadingSections,
     loadedSections,
-    deleteItem,
-    setDeleteItem,
-    projectMetadata,
-    actionMetadata,
-    sectionFileMetadata,
+    deleteItem: ui.deleteItem,
+    setDeleteItem: ui.setDeleteItem,
+    projectMetadata: overlays.projectMetadata,
+    actionMetadata: overlays.actionMetadata,
+    sectionFileMetadata: overlays.sectionFileMetadata,
     searchResults,
     filteredProjects,
     activeProjects,
@@ -1595,9 +660,9 @@ export function useGTDWorkspaceSidebar({
     handleProjectClick,
     openHorizonReadme,
     handleCreatePage,
-    toggleSection,
+    toggleSection: ui.toggleSection,
     toggleProjectExpand,
-    toggleCompletedActions,
+    toggleCompletedActions: ui.toggleCompletedActions,
     handleSelectFolder,
     handleDelete,
     handleOpenFolderInExplorer,

--- a/tests/gtd-workspace-sidebar.component.spec.tsx
+++ b/tests/gtd-workspace-sidebar.component.spec.tsx
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { GTDWorkspaceSidebar } from '@/components/gtd/GTDWorkspaceSidebar';
-import { emitMetadataChange } from '@/utils/content-event-bus';
+import { emitContentSaved, emitMetadataChange } from '@/utils/content-event-bus';
 import type { GTDProject, GTDSpace, MarkdownFile } from '@/types';
 
 const safeInvokeMock = vi.fn();
@@ -636,5 +636,182 @@ describe('GTDWorkspaceSidebar component', () => {
     );
 
     expect(aliasListCalls).toHaveLength(0);
+  });
+
+  it('does not let stale section loads overwrite the next workspace after a root switch', async () => {
+    const firstRoot = '/tmp/gtd-space-a';
+    const secondRoot = '/tmp/gtd-space-b';
+    const firstSpace: GTDSpace = {
+      root_path: firstRoot,
+      is_initialized: true,
+      isGTDSpace: true,
+      projects: [],
+      total_actions: 0,
+    };
+    const secondSpace: GTDSpace = {
+      root_path: secondRoot,
+      is_initialized: true,
+      isGTDSpace: true,
+      projects: [],
+      total_actions: 0,
+    };
+    let resolveFirstHabits:
+      | ((files: MarkdownFile[]) => void)
+      | undefined;
+
+    safeInvokeMock.mockImplementation(
+      async (command: string, args?: { path?: string }, fallback?: unknown) => {
+        if (command === 'check_directory_exists') {
+          return true;
+        }
+
+        if (command === 'list_markdown_files') {
+          switch (args?.path) {
+            case `${firstRoot}/Habits`:
+              return new Promise<MarkdownFile[]>((resolve) => {
+                resolveFirstHabits = resolve;
+              });
+            case `${secondRoot}/Habits`:
+              return [markdownFile(`${secondRoot}/Habits/Second Habit.md`, 'Second Habit.md')];
+            case `${firstRoot}/Areas of Focus`:
+            case `${firstRoot}/Goals`:
+            case `${firstRoot}/Vision`:
+            case `${firstRoot}/Purpose & Principles`:
+            case `${firstRoot}/Someday Maybe`:
+            case `${firstRoot}/Cabinet`:
+            case `${secondRoot}/Areas of Focus`:
+            case `${secondRoot}/Goals`:
+            case `${secondRoot}/Vision`:
+            case `${secondRoot}/Purpose & Principles`:
+            case `${secondRoot}/Someday Maybe`:
+            case `${secondRoot}/Cabinet`:
+              return [];
+            default:
+              return fallback ?? [];
+          }
+        }
+
+        if (command === 'read_file') return '# README';
+        if (command === 'save_file') return 'ok';
+        return fallback ?? null;
+      }
+    );
+
+    const loadProjects = vi.fn().mockResolvedValue([]);
+    const { rerender } = render(
+      <GTDWorkspaceSidebar
+        currentFolder={firstRoot}
+        gtdSpace={firstSpace}
+        checkGTDSpace={vi.fn().mockResolvedValue(true)}
+        loadProjects={loadProjects}
+        onFolderSelect={vi.fn()}
+        onFileSelect={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(resolveFirstHabits).toBeTypeOf('function');
+    });
+
+    rerender(
+      <GTDWorkspaceSidebar
+        currentFolder={secondRoot}
+        gtdSpace={secondSpace}
+        checkGTDSpace={vi.fn().mockResolvedValue(true)}
+        loadProjects={loadProjects}
+        onFolderSelect={vi.fn()}
+        onFileSelect={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText('Second Habit')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirstHabits?.([
+        markdownFile(`${firstRoot}/Habits/First Habit.md`, 'First Habit.md'),
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Second Habit')).toBeInTheDocument();
+      expect(screen.queryByText('First Habit')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders project due-date overlays before the project reload settles after README saves', async () => {
+    let resolveProjects: ((projects: GTDProject[]) => void) | undefined;
+
+    safeInvokeMock.mockImplementation(
+      async (command: string, args?: { path?: string; projectPath?: string }, fallback?: unknown) => {
+        if (command === 'check_directory_exists') {
+          return true;
+        }
+
+        if (command === 'list_project_actions' && args?.projectPath === activeProject.path) {
+          return projectActions;
+        }
+
+        if (command === 'list_markdown_files') {
+          switch (args?.path) {
+            case `${rootPath}/Habits`:
+            case `${rootPath}/Areas of Focus`:
+            case `${rootPath}/Goals`:
+            case `${rootPath}/Vision`:
+            case `${rootPath}/Purpose & Principles`:
+            case `${rootPath}/Someday Maybe`:
+            case `${rootPath}/Cabinet`:
+              return [];
+            default:
+              return fallback ?? [];
+          }
+        }
+
+        if (command === 'read_file') return '# README';
+        if (command === 'save_file') return 'ok';
+        return fallback ?? null;
+      }
+    );
+
+    const loadProjects = vi.fn().mockImplementation(
+      async () =>
+        new Promise<GTDProject[]>((resolve) => {
+          resolveProjects = resolve;
+        })
+    );
+
+    render(
+      <GTDWorkspaceSidebar
+        currentFolder={rootPath}
+        gtdSpace={gtdSpace}
+        checkGTDSpace={vi.fn().mockResolvedValue(true)}
+        loadProjects={loadProjects}
+        onFolderSelect={vi.fn()}
+        onFileSelect={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText('Project Alpha')).toBeInTheDocument();
+
+    act(() => {
+      emitContentSaved({
+        filePath: `${activeProject.path}/README.markdown`,
+        fileName: 'README.markdown',
+        content: '# Project Alpha',
+        metadata: {
+          title: 'Project Alpha',
+          due_date: '2026-04-20',
+        } as never,
+      });
+    });
+
+    expect(await screen.findByText(/2026/)).toBeInTheDocument();
+    expect(loadProjects).toHaveBeenCalledWith(rootPath);
+
+    await act(async () => {
+      resolveProjects?.(gtdSpace.projects || []);
+    });
   });
 });

--- a/tests/sidebar-event-bridge.spec.tsx
+++ b/tests/sidebar-event-bridge.spec.tsx
@@ -1,0 +1,341 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitContentSaved, emitMetadataChange } from '@/utils/content-event-bus';
+import { useGTDWorkspaceSidebar } from '@/hooks/useGTDWorkspaceSidebar';
+import type { GTDProject, GTDSpace } from '@/types';
+
+const safeInvokeMock = vi.fn();
+const readFileTextMock = vi.fn();
+const useGTDSpaceMock = vi.fn();
+
+vi.mock('@/hooks/useGTDSpace', () => ({
+  useGTDSpace: () => useGTDSpaceMock(),
+}));
+
+vi.mock('@/hooks/useErrorHandler', () => ({
+  useErrorHandler: () => ({
+    reportError: vi.fn(),
+    withErrorHandling: async <T,>(operation: () => Promise<T>) => operation(),
+  }),
+}));
+
+vi.mock('@/utils/safe-invoke', () => ({
+  safeInvoke: (...args: unknown[]) => safeInvokeMock(...args),
+}));
+
+vi.mock('@/hooks/useFileManager', () => ({
+  readFileText: (...args: unknown[]) => readFileTextMock(...args),
+}));
+
+const rootPath = '/tmp/gtd-space';
+const projectPath = `${rootPath}/Projects/Project Alpha`;
+const actionPath = `${projectPath}/Write spec.md`;
+const sectionFilePath = `${rootPath}/Habits/Morning Run.md`;
+
+const gtdSpace: GTDSpace = {
+  root_path: rootPath,
+  is_initialized: true,
+  isGTDSpace: true,
+  projects: [],
+  total_actions: 0,
+};
+
+let latestSidebar: ReturnType<typeof useGTDWorkspaceSidebar> | null = null;
+
+function SidebarHookHarness({
+  loadProjects = vi.fn().mockResolvedValue([]),
+}: {
+  loadProjects?: (path: string) => Promise<unknown>;
+}) {
+  const sidebar = useGTDWorkspaceSidebar({
+    currentFolder: null,
+    onFolderSelect: vi.fn(),
+    onFileSelect: vi.fn(),
+    onRefresh: vi.fn(),
+    gtdSpace,
+    checkGTDSpace: vi.fn().mockResolvedValue(true),
+    loadProjects: loadProjects as (path: string) => Promise<GTDProject[]>,
+    activeFilePath: null,
+  });
+
+  React.useLayoutEffect(() => {
+    latestSidebar = sidebar;
+  }, [sidebar]);
+
+  return null;
+}
+
+function listenForEvent<T>(eventName: string) {
+  const details: T[] = [];
+  const listener = (event: Event) => {
+    details.push((event as CustomEvent<T>).detail);
+  };
+
+  window.addEventListener(eventName, listener as EventListener);
+
+  return {
+    details,
+    dispose: () => window.removeEventListener(eventName, listener as EventListener),
+  };
+}
+
+describe('sidebar event bridge', () => {
+  beforeEach(() => {
+    latestSidebar = null;
+    vi.clearAllMocks();
+    useGTDSpaceMock.mockReturnValue({
+      gtdSpace: null,
+      isLoading: false,
+      checkGTDSpace: vi.fn().mockResolvedValue(false),
+      loadProjects: vi.fn().mockResolvedValue([]),
+    });
+    readFileTextMock.mockResolvedValue('# Action');
+  });
+
+  it('updates project and action overlays from metadata events', async () => {
+    render(<SidebarHookHarness />);
+
+    act(() => {
+      emitMetadataChange({
+        filePath: `${projectPath}/README.markdown`,
+        fileName: 'README.markdown',
+        content: '# Project Alpha',
+        metadata: {
+          projectStatus: 'completed',
+          due_date: '2026-04-15',
+        } as never,
+        changedFields: {
+          projectStatus: 'completed',
+          due_date: '2026-04-15',
+        } as never,
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestSidebar?.projectMetadata[projectPath]).toMatchObject({
+        status: 'completed',
+        due_date: '2026-04-15',
+      });
+    });
+
+    act(() => {
+      emitMetadataChange({
+        filePath: actionPath,
+        fileName: 'Write spec.md',
+        content: '# Write spec',
+        metadata: {
+          status: 'waiting_for',
+          due_date: '2026-04-16',
+        } as never,
+        changedFields: {
+          status: 'waiting_for',
+          due_date: '2026-04-16',
+        } as never,
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestSidebar?.actionStatuses[actionPath]).toBe('waiting_for');
+      expect(latestSidebar?.actionMetadata[actionPath]).toMatchObject({
+        status: 'waiting_for',
+        due_date: '2026-04-16',
+      });
+    });
+  });
+
+  it('dispatches project rename events with normalized paths', async () => {
+    const loadProjects = vi.fn().mockResolvedValue([]);
+    const projectRenamed = listenForEvent<{
+      oldPath: string;
+      newPath: string;
+      newName: string;
+    }>('project-renamed');
+
+    safeInvokeMock.mockImplementation(async (command: string, _args?: unknown, fallback?: unknown) => {
+      if (command === 'rename_gtd_project') {
+        return `${rootPath}/Projects/Project Beta`;
+      }
+      return fallback ?? null;
+    });
+
+    render(<SidebarHookHarness loadProjects={loadProjects} />);
+
+    act(() => {
+      emitContentSaved({
+        filePath: `${projectPath}/README.markdown`,
+        fileName: 'README.markdown',
+        content: '# Project Alpha',
+        metadata: {
+          title: 'Project Beta',
+          due_date: '2026-04-20',
+        } as never,
+      });
+    });
+
+    await waitFor(() => {
+      expect(projectRenamed.details).toEqual([
+        {
+          oldPath: projectPath,
+          newPath: `${rootPath}/Projects/Project Beta`,
+          newName: 'Project Beta',
+        },
+      ]);
+    });
+
+    expect(loadProjects).toHaveBeenCalledWith(rootPath);
+    projectRenamed.dispose();
+  });
+
+  it('dispatches action rename and file rename events', async () => {
+    const actionRenamed = listenForEvent<{
+      oldPath: string;
+      newPath: string;
+      newName: string;
+    }>('action-renamed');
+    const fileRenamed = listenForEvent<{ oldPath: string; newPath: string }>('file-renamed');
+
+    safeInvokeMock.mockImplementation(async (command: string, args?: { path?: string }, fallback?: unknown) => {
+      if (command === 'rename_gtd_action') {
+        return `${projectPath}/Write spec updated.md`;
+      }
+      if (command === 'list_project_actions') {
+        return [];
+      }
+      if (command === 'list_markdown_files') {
+        return [];
+      }
+      return args?.path ?? fallback ?? null;
+    });
+
+    render(<SidebarHookHarness />);
+
+    act(() => {
+      emitContentSaved({
+        filePath: actionPath,
+        fileName: 'Write spec.md',
+        content: '# Write spec',
+        metadata: {
+          title: 'Write spec updated',
+        } as never,
+      });
+    });
+
+    await waitFor(() => {
+      expect(actionRenamed.details).toEqual([
+        {
+          oldPath: actionPath,
+          newPath: `${projectPath}/Write spec updated.md`,
+          newName: 'Write spec updated',
+        },
+      ]);
+      expect(fileRenamed.details).toContainEqual({
+        oldPath: actionPath,
+        newPath: `${projectPath}/Write spec updated.md`,
+      });
+    });
+
+    actionRenamed.dispose();
+    fileRenamed.dispose();
+  });
+
+  it('dispatches section file rename events', async () => {
+    const sectionFileRenamed = listenForEvent<{
+      oldPath: string;
+      newPath: string;
+      newName: string;
+    }>('section-file-renamed');
+    const fileRenamed = listenForEvent<{ oldPath: string; newPath: string }>('file-renamed');
+
+    safeInvokeMock.mockImplementation(async (command: string, args?: { path?: string }, fallback?: unknown) => {
+      if (command === 'rename_file') {
+        return {
+          success: true,
+          path: `${rootPath}/Habits/Habit Renamed.md`,
+        };
+      }
+      if (command === 'check_directory_exists') {
+        return true;
+      }
+      if (command === 'list_markdown_files') {
+        return [];
+      }
+      return args?.path ?? fallback ?? null;
+    });
+
+    render(<SidebarHookHarness />);
+
+    act(() => {
+      emitContentSaved({
+        filePath: sectionFilePath,
+        fileName: 'Morning Run.md',
+        content: '# Morning Run',
+        metadata: {
+          title: 'Habit Renamed',
+        } as never,
+      });
+    });
+
+    await waitFor(() => {
+      expect(sectionFileRenamed.details).toEqual([
+        {
+          oldPath: sectionFilePath,
+          newPath: `${rootPath}/Habits/Habit Renamed.md`,
+          newName: 'Habit Renamed',
+        },
+      ]);
+      expect(fileRenamed.details).toContainEqual({
+        oldPath: sectionFilePath,
+        newPath: `${rootPath}/Habits/Habit Renamed.md`,
+      });
+    });
+
+    sectionFileRenamed.dispose();
+    fileRenamed.dispose();
+  });
+
+  it('dispatches file deleted events from the controller delete flow', async () => {
+    const fileDeleted = listenForEvent<{ path: string }>('file-deleted');
+
+    safeInvokeMock.mockImplementation(async (command: string, _args?: { path?: string }, fallback?: unknown) => {
+      if (command === 'delete_file') {
+        return { success: true, path: sectionFilePath };
+      }
+      if (command === 'check_directory_exists') {
+        return true;
+      }
+      if (command === 'list_markdown_files') {
+        return [];
+      }
+      return fallback ?? null;
+    });
+
+    render(<SidebarHookHarness />);
+
+    await act(async () => {
+      latestSidebar?.setDeleteItem({
+        type: 'file',
+        path: sectionFilePath,
+        name: 'Morning Run',
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestSidebar?.deleteItem).toMatchObject({
+        type: 'file',
+        path: sectionFilePath,
+      });
+    });
+
+    await act(async () => {
+      await latestSidebar?.handleDelete();
+    });
+
+    await waitFor(() => {
+      expect(fileDeleted.details).toEqual([{ path: sectionFilePath }]);
+    });
+
+    fileDeleted.dispose();
+  });
+});

--- a/tests/sidebar-path-classification.spec.ts
+++ b/tests/sidebar-path-classification.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifySidebarPath,
+  extractProjectPathFromReadme,
+  isProjectActionPath,
+  isProjectReadmePath,
+  isReadmePath,
+  isSectionFilePath,
+  matchesSectionPathVariants,
+  normalizeSidebarPath,
+} from '@/hooks/sidebar/path-classification';
+
+const rootPath = '/tmp/gtd-space';
+
+describe('sidebar path classification', () => {
+  it('classifies project README paths for md and markdown files', () => {
+    const markdownPath = `${rootPath}\\Projects\\Project Alpha\\README.markdown`;
+
+    expect(isReadmePath(markdownPath)).toBe(true);
+    expect(isProjectReadmePath(markdownPath, rootPath)).toBe(true);
+    expect(extractProjectPathFromReadme(markdownPath)).toBe(
+      `${rootPath}/Projects/Project Alpha`
+    );
+    expect(classifySidebarPath(markdownPath, rootPath)).toMatchObject({
+      kind: 'project-readme',
+      normalizedPath: `${rootPath}/Projects/Project Alpha/README.markdown`,
+      projectPath: `${rootPath}/Projects/Project Alpha`,
+    });
+  });
+
+  it('classifies project action files and excludes README files', () => {
+    const actionPath = `${rootPath}/Projects/Project Alpha/Write spec.md`;
+    const readmePath = `${rootPath}/Projects/Project Alpha/README.md`;
+
+    expect(isProjectActionPath(actionPath, rootPath)).toBe(true);
+    expect(isProjectActionPath(readmePath, rootPath)).toBe(false);
+    expect(classifySidebarPath(actionPath, rootPath)).toMatchObject({
+      kind: 'project-action',
+      projectPath: `${rootPath}/Projects/Project Alpha`,
+    });
+  });
+
+  it('classifies section files across canonical and alias section folders', () => {
+    const canonicalPath = `${rootPath}/Purpose & Principles/Focus.md`;
+    const aliasPath = `${rootPath}/Purpose and Principles/Focus.markdown`;
+
+    expect(isSectionFilePath(canonicalPath, rootPath)).toBe(true);
+    expect(isSectionFilePath(aliasPath, rootPath)).toBe(true);
+    expect(matchesSectionPathVariants(aliasPath, ['purpose'], rootPath)).toBe(true);
+    expect(classifySidebarPath(canonicalPath, rootPath)).toMatchObject({
+      kind: 'section-file',
+      sectionId: 'purpose',
+      sectionPath: `${rootPath}/Purpose & Principles`,
+    });
+  });
+
+  it('supports rootless alias classification before the workspace root is hydrated', () => {
+    const aliasPath = `${rootPath}/Purpose and Principles/Focus.markdown`;
+    const canonicalPath = `${rootPath}/Purpose & Principles/Focus.markdown`;
+
+    expect(normalizeSidebarPath(aliasPath)).toBe(canonicalPath);
+    expect(isSectionFilePath(aliasPath)).toBe(true);
+    expect(classifySidebarPath(aliasPath)).toMatchObject({
+      kind: 'section-file',
+      sectionId: 'purpose',
+      normalizedPath: canonicalPath,
+      sectionPath: `${rootPath}/Purpose & Principles`,
+    });
+  });
+
+  it('returns other for unrelated files', () => {
+    expect(classifySidebarPath('/tmp/notes/README.md', rootPath)).toEqual({
+      kind: 'other',
+      normalizedPath: '/tmp/notes/README.md',
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Refactored the GTD workspace sidebar controller so `useGTDWorkspaceSidebar` is now a composition layer instead of the place where UI state, overlays, async loading, lifecycle resets, and event-bus orchestration all live.

This extracts the sidebar logic into focused internal hooks and helpers:

- `src/hooks/sidebar/path-classification.ts`
- `src/hooks/sidebar/types.ts`
- `src/hooks/sidebar/useSidebarUiState.ts`
- `src/hooks/sidebar/useSidebarOverlays.ts`
- `src/hooks/sidebar/useSidebarDataLoaders.ts`
- `src/hooks/sidebar/useSidebarWorkspaceLifecycle.ts`
- `src/hooks/sidebar/useSidebarEventBridge.ts`

It also updates shared sidebar utilities to use the centralized path normalization/classification logic and adds targeted coverage for the new controller boundaries.

## Why it changed

`useGTDWorkspaceSidebar` had become a single large hotspot that mixed:

- dialog and expansion state
- optimistic metadata overlays
- section/project loading
- workspace root reset logic
- global content-event subscriptions
- rename/delete reconciliation

That made sidebar behavior hard to reason about and increased the risk of stale-path, rename, and workspace-switch bugs.

## Impact

Behavior and external contracts stay the same for callers of `GTDWorkspaceSidebar` and `useGTDWorkspaceSidebar`, but the internals are now split by responsibility.

This also folds in low-risk fixes that fall directly out of the refactor:

- shared `.md` / `.markdown` README and path classification
- consistent alias handling for section paths
- stale workspace-load protection coverage
- direct tests for event-bridge rename and delete flows

## Root cause

The sidebar controller had accumulated multiple sources of truth over time. Path detection, metadata overlay updates, and async reload logic were spread across one hook with repeated string matching and effect orchestration.

## Validation

- `npm run type-check`
- `npm run lint`
- `npx vitest run tests/gtd-workspace-sidebar.component.spec.tsx tests/app.integration.spec.tsx tests/sidebar-path-classification.spec.ts tests/sidebar-event-bridge.spec.tsx`
- `cd src-tauri && cargo fmt --check && cargo clippy -- -D warnings`

## Notes

- PR targets `staging`
- CodeRabbit CLI was run on the local changes before publish
- The unrelated local `AGENTS.md` modification was intentionally left out of this PR