### PR TITLE
[codex] release: bump version to v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtdspace",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gtdspace",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@blocknote/code-block": "~0.37.0",
         "@blocknote/core": "~0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gtdspace",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "GTD-first productivity system with integrated markdown editing",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtdspace"
-version = "2.5.1"
+version = "2.6.0"
 description = "GTD-first productivity system with integrated markdown editing"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/mcp-server/Cargo.lock
+++ b/src-tauri/mcp-server/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "GTD Space",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "identifier": "com.gtdspace.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary\n- bump the shipped app version to v2.6.0\n- update package and Tauri version surfaces\n- publish tag v2.6.0 for the release workflow\n\n## Verification\n- npm run release:minor\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 2.5.1 to 2.6.0 across all project configuration files and package manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->