### PR TITLE
[codex] fix: align v2.6.0 Tauri dialog package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@shikijs/langs-precompiled": "^3.12.2",
         "@tauri-apps/api": "^2.10.1",
-        "@tauri-apps/plugin-dialog": "^2.6.0",
+        "@tauri-apps/plugin-dialog": "^2.7.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "codemirror": "^6.0.2",
@@ -4010,12 +4010,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
-      "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
+      "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@shikijs/langs-precompiled": "^3.12.2",
     "@tauri-apps/api": "^2.10.1",
-    "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.2",


### PR DESCRIPTION
## What changed
Aligns the frontend `@tauri-apps/plugin-dialog` package with the Rust `tauri-plugin-dialog` version already in `src-tauri`.

## Why
The first `v2.6.0` release tag triggered a failing `Build and Release` workflow because Tauri packaging detected a plugin version mismatch:
- Rust crate: `tauri-plugin-dialog` `2.7.0`
- JS package: `@tauri-apps/plugin-dialog` `2.6.0`

## Impact
This unblocks packaging for the already-bumped `2.6.0` release and allows the tag to be recreated from a consistent main branch.

## Validation
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm run tauri build -- --no-bundle`
- Previous release bump validation already passed before the first tag attempt:
  - `npm run test:run`
  - `npm run test:release:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying dependencies to latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->