### PR TITLE
Add dashboard activity feed and horizon relationship map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,9 @@
 
 - Keep API keys in `.env`.
 - Review `src-tauri/capabilities/` and CSP changes carefully.
+
+## Engineering Principles
+**1. Think Before Coding**: State assumptions, surface uncertainty, and present tradeoffs.
+**2. Simplicity First**: Minimum code required. No speculative features or unnecessary abstractions.
+**3. Surgical Changes**: Touch only what is necessary. Match existing style.
+**4. Goal-Driven Execution**: Define success via verifiable tests/checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - Review `src-tauri/capabilities/` and CSP changes carefully.
 
 ## Engineering Principles
+
 **1. Think Before Coding**: State assumptions, surface uncertainty, and present tradeoffs.
 **2. Simplicity First**: Minimum code required. No speculative features or unnecessary abstractions.
 **3. Surgical Changes**: Touch only what is necessary. Match existing style.

--- a/src-tauri/mcp-server/Cargo.lock
+++ b/src-tauri/mcp-server/Cargo.lock
@@ -482,6 +482,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5205,9 +5215,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"
@@ -5655,9 +5668,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -5673,13 +5686,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.5"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding 2.3.2",
  "schemars 0.8.22",
  "serde",

--- a/src/components/dashboard/DashboardHabits.tsx
+++ b/src/components/dashboard/DashboardHabits.tsx
@@ -48,6 +48,7 @@ interface DashboardHabitsProps {
 
 // Frequency display mapping (must align with GTDHabitFrequency)
 const FREQUENCY_DISPLAY: Record<string, string> = {
+  '5-minute': 'Every 5 Minutes',
   'daily': 'Daily',
   'every-other-day': 'Every Other Day',
   'twice-weekly': 'Twice Weekly',

--- a/src/components/dashboard/DashboardHorizons.tsx
+++ b/src/components/dashboard/DashboardHorizons.tsx
@@ -2,7 +2,7 @@
  * @fileoverview Dashboard Horizons Tab - Hierarchical view of GTD levels with relationships
  */
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -31,16 +31,15 @@ import {
   Mountain,
   Plus,
   Search,
-  Sparkles,
   Star,
   Target,
-  TreePine
 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import type { GTDProject } from '@/types';
 import type { HorizonFile as HookHorizonFile, HorizonRelationship as HookHorizonRelationship } from '@/hooks/useHorizonsRelationships';
 import { mergeProjectInfoIntoHorizonFiles } from '@/utils/horizons';
 import { cn } from '@/lib/utils';
+import { HorizonRelationshipMap } from '@/components/dashboard/HorizonRelationshipMap';
 
 // Helper type for relationships with optional name properties
 type NamedRelationship = HookHorizonRelationship & { toName?: string; fromName?: string };
@@ -106,11 +105,23 @@ type HorizonFile = HookHorizonFile & {
 };
 
 type HorizonRelationship = HookHorizonRelationship;
+type HorizonGraph = {
+  nodes: Array<{ id: string; label: string; level: string; group: number }>;
+  edges: Array<{ from: string; to: string }>;
+};
 
 interface DashboardHorizonsProps {
   horizonFiles: Record<string, HorizonFile[]>;
   projects: GTDProject[];
   relationships?: HorizonRelationship[];
+  graph?: HorizonGraph;
+  findRelated?: (filePath: string) => {
+    parents: HorizonFile[];
+    children: HorizonFile[];
+    siblings: HorizonFile[];
+  };
+  selectedLevel?: string;
+  onSelectedLevelChange?: (value: string) => void;
   isLoading?: boolean;
   onSelectFile?: (file: HorizonFile) => void;
   onCreateFile?: (horizon: string) => void;
@@ -121,6 +132,10 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
   horizonFiles,
   projects,
   relationships = [],
+  graph = { nodes: [], edges: [] },
+  findRelated,
+  selectedLevel: controlledSelectedLevel,
+  onSelectedLevelChange,
   isLoading = false,
   onSelectFile,
   onCreateFile,
@@ -130,8 +145,18 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [showOnlyLinked, setShowOnlyLinked] = useState(false);
-  const [selectedLevel, setSelectedLevel] = useState<string>('All');
+  const [uncontrolledSelectedLevel, setUncontrolledSelectedLevel] = useState<string>('All');
   const [sortBy, setSortBy] = useState<'name' | 'linked'>('name');
+  const [selectedNodePath, setSelectedNodePath] = useState<string | null>(null);
+  const isLevelControlled = controlledSelectedLevel !== undefined;
+  const selectedLevel = controlledSelectedLevel ?? uncontrolledSelectedLevel;
+
+  const setSelectedLevel = useCallback((value: string) => {
+    onSelectedLevelChange?.(value);
+    if (!isLevelControlled) {
+      setUncontrolledSelectedLevel(value);
+    }
+  }, [isLevelControlled, onSelectedLevelChange]);
 
   // Toggle level expansion
   const toggleLevel = useCallback((levelName: string) => {
@@ -159,38 +184,19 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
     });
   }, []);
 
-  // Filter files based on search
-  const filteredHorizonFiles = useMemo(() => {
-    if (!searchQuery && !showOnlyLinked) return horizonFiles;
+  const filesByLevel = useMemo(() => {
+    const next: Record<string, HorizonFile[]> = {};
 
-    const filtered: Record<string, HorizonFile[]> = {};
-    
-    Object.entries(horizonFiles).forEach(([level, files]) => {
-      let levelFiles = [...files];
-      
-      // Search filter
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase();
-        levelFiles = levelFiles.filter(file =>
-          file.name.toLowerCase().includes(query)
-        );
-      }
-      
-      // Linked filter
-      if (showOnlyLinked) {
-        levelFiles = levelFiles.filter(file =>
-          (file.linkedTo && file.linkedTo.length > 0) ||
-          (file.linkedFrom && file.linkedFrom.length > 0)
-        );
-      }
-      
-      if (levelFiles.length > 0) {
-        filtered[level] = levelFiles;
-      }
+    HORIZON_LEVELS.forEach((level) => {
+      const rawFiles = (horizonFiles[level.name] as HorizonFile[]) || [];
+      next[level.name] =
+        level.name === 'Projects' && projects.length > 0
+          ? mergeProjectInfoIntoHorizonFiles(rawFiles, projects as any)
+          : rawFiles;
     });
-    
-    return filtered;
-  }, [horizonFiles, searchQuery, showOnlyLinked]);
+
+    return next;
+  }, [horizonFiles, projects]);
 
   // Calculate statistics
   const stats = useMemo(() => {
@@ -198,32 +204,15 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
     let linkedFiles = 0;
     const levelCounts: Record<string, number> = {};
 
-    const entries = Object.entries(horizonFiles);
-    const hasProjectsKey = entries.some(([level]) => level === 'Projects');
-
-    entries.forEach(([level, files]) => {
+    HORIZON_LEVELS.forEach((level) => {
+      const files = filesByLevel[level.name] ?? [];
       totalFiles += files.length;
       linkedFiles += files.filter(f =>
         (f.linkedTo && f.linkedTo.length > 0) ||
         (f.linkedFrom && f.linkedFrom.length > 0)
       ).length;
-      levelCounts[level] = files.length;
+      levelCounts[level.name] = files.length;
     });
-
-    // Only add projects from the separate projects array if the horizonFiles
-    // set does not already contain the Projects bucket.
-    if (!hasProjectsKey) {
-      levelCounts['Projects'] = projects.length;
-      totalFiles += projects.length;
-
-      // Estimate linked count from project metadata when adding projects here
-      linkedFiles += projects.filter((p: any) =>
-        (Array.isArray(p.linkedAreas) && p.linkedAreas.length > 0) ||
-        (Array.isArray(p.linkedGoals) && p.linkedGoals.length > 0) ||
-        (Array.isArray(p.linkedVision) && p.linkedVision.length > 0) ||
-        (Array.isArray(p.linkedPurpose) && p.linkedPurpose.length > 0)
-      ).length;
-    }
 
     return {
       totalFiles,
@@ -231,7 +220,7 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
       levelCounts,
       linkageRate: totalFiles > 0 ? Math.round((linkedFiles / totalFiles) * 100) : 0
     };
-  }, [horizonFiles, projects]);
+  }, [filesByLevel]);
 
   // Get relationships for a file
   const getFileRelationships = useCallback((filePath: string) => {
@@ -241,30 +230,78 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
     };
   }, [relationships]);
 
+  const filteredHorizonFiles = useMemo(() => {
+    const filtered: Record<string, HorizonFile[]> = {};
+    const query = searchQuery.trim().toLowerCase();
+
+    HORIZON_LEVELS.forEach((level) => {
+      let levelFiles = [...(filesByLevel[level.name] ?? [])];
+
+      if (query) {
+        levelFiles = levelFiles.filter((file) =>
+          file.name.toLowerCase().includes(query) ||
+          file.content?.toLowerCase().includes(query)
+        );
+      }
+
+      if (showOnlyLinked) {
+        levelFiles = levelFiles.filter((file) =>
+          (file.linkedTo && file.linkedTo.length > 0) ||
+          (file.linkedFrom && file.linkedFrom.length > 0)
+        );
+      }
+
+      filtered[level.name] = [...levelFiles].sort((a, b) => {
+        if (sortBy === 'linked') {
+          const aRel = getFileRelationships(a.path);
+          const bRel = getFileRelationships(b.path);
+          const aCount = aRel.linkedTo.length + aRel.linkedFrom.length;
+          const bCount = bRel.linkedTo.length + bRel.linkedFrom.length;
+          if (bCount !== aCount) return bCount - aCount;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    });
+
+    return filtered;
+  }, [filesByLevel, getFileRelationships, searchQuery, showOnlyLinked, sortBy]);
+
+  const visiblePaths = useMemo(() => {
+    const next = new Set<string>();
+    Object.values(filteredHorizonFiles).forEach((files) => {
+      files.forEach((file) => next.add(file.path));
+    });
+    return next;
+  }, [filteredHorizonFiles]);
+
+  useEffect(() => {
+    if (selectedLevel !== 'All') {
+      setExpandedLevels((prev) => {
+        if (prev.has(selectedLevel)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.add(selectedLevel);
+        return next;
+      });
+    }
+  }, [selectedLevel]);
+
+  useEffect(() => {
+    if (selectedNodePath && !visiblePaths.has(selectedNodePath)) {
+      setSelectedNodePath(null);
+    }
+  }, [selectedNodePath, visiblePaths]);
+
+  const handleSelectFile = useCallback((file: HorizonFile) => {
+    setSelectedNodePath(file.path);
+    onSelectFile?.(file);
+  }, [onSelectFile]);
+
   // Render horizon level
   const renderHorizonLevel = (level: HorizonLevel) => {
     const isExpanded = expandedLevels.has(level.name);
-    // Start with files provided for this level
-    let files: HorizonFile[] = (filteredHorizonFiles[level.name] as HorizonFile[]) || [];
-
-    // For Projects, enrich from `projects` prop where available (action counts, etc.)
-    if (level.name === 'Projects' && projects.length > 0) {
-      files = mergeProjectInfoIntoHorizonFiles(files, projects as any);
-
-      // Apply search and linked-only filters to projects too (already handled above via filteredHorizonFiles)
-    }
-
-    // Apply sorting
-    files = [...files].sort((a, b) => {
-      if (sortBy === 'linked') {
-        const aRel = getFileRelationships(a.path);
-        const bRel = getFileRelationships(b.path);
-        const aCount = aRel.linkedTo.length + aRel.linkedFrom.length;
-        const bCount = bRel.linkedTo.length + bRel.linkedFrom.length;
-        if (bCount !== aCount) return bCount - aCount;
-      }
-      return a.name.localeCompare(b.name);
-    });
+    const files: HorizonFile[] = filteredHorizonFiles[level.name] || [];
     const fileCount = files.length;
     const LevelIcon = level.icon;
 
@@ -356,6 +393,7 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
         key={file.path}
         className={cn(
           "border rounded-lg p-3 hover:bg-accent transition-colors",
+          selectedNodePath === file.path && "border-primary bg-primary/5",
           hasRelationships && "border-primary/30"
         )}
       >
@@ -378,7 +416,7 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
               <FileText className="h-4 w-4 text-muted-foreground" />
               <span 
                 className="font-medium cursor-pointer hover:text-primary"
-                onClick={() => onSelectFile?.(file)}
+                onClick={() => handleSelectFile(file)}
               >
                 {file.name.replace('.md', '')}
               </span>
@@ -550,7 +588,6 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
         </Select>
       </div>
 
-      {/* Horizon pyramid visualization */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -627,27 +664,16 @@ export const DashboardHorizons: React.FC<DashboardHorizonsProps> = ({
         </CardContent>
       </Card>
 
-      {/* Relationship graph placeholder */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <TreePine className="h-5 w-5" />
-            Relationship Map
-          </CardTitle>
-          <CardDescription>
-            Visual connections between your horizons
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="h-[200px] flex items-center justify-center text-muted-foreground">
-            <div className="text-center">
-              <Sparkles className="h-12 w-12 mx-auto mb-3 opacity-30" />
-              <p className="text-sm">Interactive relationship graph</p>
-              <p className="text-xs mt-1">Coming soon...</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <HorizonRelationshipMap
+        allFilesByLevel={filesByLevel}
+        visibleFilesByLevel={filteredHorizonFiles}
+        graph={graph}
+        selectedLevel={selectedLevel}
+        selectedNodePath={selectedNodePath}
+        findRelated={findRelated}
+        onSelectNode={setSelectedNodePath}
+        onOpenFile={(file) => handleSelectFile(file as HorizonFile)}
+      />
     </div>
   );
 };

--- a/src/components/dashboard/DashboardOverview.tsx
+++ b/src/components/dashboard/DashboardOverview.tsx
@@ -10,9 +10,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Activity,
   AlertCircle,
-  Calendar,
   Clock,
-  FileText,
   FolderOpen,
   Layers,
   ListChecks,
@@ -32,15 +30,17 @@ import type { HabitWithHistory } from '@/hooks/useHabitsHistory';
 import { cn } from '@/lib/utils';
 import { countHabitsCompletedOnDate } from '@/utils/habit-progress';
 import { localISODate } from '@/utils/time';
-import { Switch } from '@/components/ui/switch';
 import {
   formatRelativeDate,
-  getDateFromNow,
-  isDateInRange,
   isDateOverdue,
-  parseLocalDate,
 } from '@/utils/date-formatting';
 import { QuestionMarkTooltip } from '@/components/ui/QuestionMarkTooltip';
+import { UpcomingDeadlinesCard } from '@/components/dashboard/UpcomingDeadlinesCard';
+import type {
+  DashboardActivityEntityType,
+  DashboardActivityItem,
+  DashboardActivityType,
+} from '@/utils/dashboard-activity';
 
 interface DashboardOverviewProps {
   gtdSpace: GTDSpace;
@@ -58,11 +58,13 @@ interface DashboardOverviewProps {
     dueThisWeek?: number;
   };
   horizonCounts: Record<string, number>;
+  recentActivity: DashboardActivityItem[];
   isLoading?: boolean;
   onNewProject?: () => void;
   onSelectProject?: (path: string) => void;
   onSelectHorizon?: (name: string) => void;
   onSelectAction?: (path: string) => void;
+  onSelectActivity?: (item: DashboardActivityItem) => void;
 }
 
 interface QuickStat {
@@ -83,15 +85,19 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
   actions = [],
   actionSummary,
   horizonCounts,
+  recentActivity,
   isLoading = false,
   onNewProject,
   onSelectProject,
   onSelectHorizon,
-  onSelectAction
+  onSelectAction,
+  onSelectActivity,
 }) => {
-  const [includeActions, setIncludeActions] = React.useState(true);
-  const [onlyOverdue, setOnlyOverdue] = React.useState(false);
   const todayStr = localISODate(new Date());
+  const horizonOrder = React.useMemo(
+    () => ['Purpose & Principles', 'Vision', 'Goals', 'Areas of Focus', 'Projects'],
+    []
+  );
   // Calculate project statistics with enhanced metadata
   const projectStats = React.useMemo(() => {
     const active = projects.filter(p => p.status === 'in-progress').length;
@@ -210,11 +216,37 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
     return 0;
   }, [projectStats, actionSummary, habitStats]);
 
-  // Calculate upcoming due items (this week excluding today)
   const upcomingDueCount = Math.max(
     (actionSummary.dueThisWeek ?? 0) - (actionSummary.dueToday ?? 0),
     0
   );
+
+  const getActivityEntityIcon = (entityType: DashboardActivityEntityType) => {
+    switch (entityType) {
+      case 'project':
+        return FolderOpen;
+      case 'action':
+        return ListChecks;
+      case 'habit':
+        return RefreshCw;
+      case 'horizon':
+        return Layers;
+      default:
+        return Activity;
+    }
+  };
+
+  const getActivityBadgeClassName = (activityType: DashboardActivityType) => {
+    switch (activityType) {
+      case 'completed':
+        return 'border-green-500/30 bg-green-500/10 text-green-600';
+      case 'updated':
+        return 'border-blue-500/30 bg-blue-500/10 text-blue-600';
+      case 'created':
+      default:
+        return 'border-orange-500/30 bg-orange-500/10 text-orange-600';
+    }
+  };
 
   const quickStats: QuickStat[] = [
     {
@@ -276,53 +308,6 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
       description: `${habitStats.completionRate}% completed today`
     }
   ];
-
-  // Get upcoming items (next 7 days) with enhanced display
-  const upcomingItems = React.useMemo(() => {
-    const now = new Date();
-    const weekFromNow = getDateFromNow(7);
-    
-    const upcomingProjects = projects
-      .filter(p => {
-        if (!p.dueDate || p.status === 'completed' || p.status === 'cancelled') return false;
-        if (onlyOverdue) {
-          return isDateOverdue(p.dueDate);
-        }
-        return isDateInRange(p.dueDate, now, weekFromNow);
-      })
-      .map(p => ({
-        id: p.path,
-        name: p.name,
-        type: 'project' as const,
-        dueDate: p.dueDate!,
-        status: p.status,
-        completionPercentage: p.completionPercentage
-      }));
-
-    const upcomingActions = actions
-      .filter(a => {
-        if (!a.dueDate) return false;
-        if (a.status === 'completed' || a.status === 'cancelled') return false;
-        if (onlyOverdue) {
-          return isDateOverdue(a.dueDate);
-        }
-        return isDateInRange(a.dueDate, now, weekFromNow);
-      })
-      .map(a => ({
-        id: a.path,
-        name: a.name,
-        type: 'action' as const,
-        dueDate: a.dueDate!,
-        status: a.status,
-        completionPercentage: undefined as number | undefined
-      }));
-
-    // Sort combined by due date
-    const combined = includeActions ? [...upcomingProjects, ...upcomingActions] : upcomingProjects;
-    return combined
-      .sort((a, b) => parseLocalDate(a.dueDate).getTime() - parseLocalDate(b.dueDate).getTime())
-      .slice(0, 8);
-  }, [projects, actions, includeActions, onlyOverdue]);
 
   // Habits needing attention
   const habitsNeedingAttention = React.useMemo(() => {
@@ -558,9 +543,9 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
             <CardContent>
               <div className="space-y-2">
                 {Object.entries(horizonCounts)
+                  .filter(([horizon]) => horizonOrder.includes(horizon))
                   .sort((a, b) => {
-                    const order = ['Purpose & Principles', 'Vision', 'Goals', 'Areas of Focus', 'Projects'];
-                    return order.indexOf(a[0]) - order.indexOf(b[0]);
+                    return horizonOrder.indexOf(a[0]) - horizonOrder.indexOf(b[0]);
                   })
                   .map(([horizon, count]) => (
                   <div
@@ -579,101 +564,12 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
 
         {/* Right Column */}
         <div className="space-y-6">
-          {/* Upcoming Deadlines */}
-          <Card>
-            <CardHeader>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <CardTitle className="flex items-center gap-2">
-                  <Calendar className="h-5 w-5" />
-                  Upcoming Deadlines
-                </CardTitle>
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    className={cn(
-                      'text-xs px-2 py-1 rounded border transition-colors',
-                      onlyOverdue
-                        ? 'bg-destructive/10 border-destructive text-destructive'
-                        : 'border-muted-foreground/30 text-muted-foreground hover:bg-accent'
-                    )}
-                    onClick={() => setOnlyOverdue(v => !v)}
-                    aria-pressed={onlyOverdue}
-                  >
-                    Only overdue
-                  </button>
-                  <div className="flex items-center gap-2">
-                    <span id="upcoming-deadlines-include-actions" className="text-xs text-muted-foreground">
-                      Include actions
-                    </span>
-                    <Switch
-                      checked={includeActions}
-                      onCheckedChange={setIncludeActions}
-                      aria-labelledby="upcoming-deadlines-include-actions"
-                    />
-                  </div>
-                </div>
-              </div>
-              <CardDescription>{onlyOverdue ? 'Overdue' : 'Next 7 days'}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {upcomingItems.length === 0 ? (
-                <div className="text-center py-4 text-sm text-muted-foreground">
-                  {onlyOverdue ? 'No overdue items' : 'No upcoming deadlines this week'}
-                </div>
-              ) : (
-                <ScrollArea className="h-[200px]">
-                  <div className="space-y-2">
-                    {upcomingItems.map((item) => (
-                      <div
-                        key={item.id}
-                        className="cursor-pointer rounded-lg border border-border/70 p-3 transition-colors hover:bg-accent/30"
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => item.type === 'action' ? onSelectAction?.(item.id) : onSelectProject?.(item.id)}
-                        onKeyDown={(event) => {
-                          if (event.key !== 'Enter' && event.key !== ' ') {
-                            return;
-                          }
-                          event.preventDefault();
-                          if (item.type === 'action') {
-                            onSelectAction?.(item.id);
-                          } else {
-                            onSelectProject?.(item.id);
-                          }
-                        }}
-                      >
-                        <div className="mb-1 flex items-center justify-between gap-3">
-                          <span className="flex items-center gap-2 truncate text-sm font-medium">
-                            {item.type === 'project' ? (
-                              <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
-                            ) : (
-                              <FileText className="h-3.5 w-3.5 text-muted-foreground" />
-                            )}
-                            {item.name}
-                          </span>
-                          <Badge variant="outline" className="text-xs">
-                            {formatRelativeDate(item.dueDate) || parseLocalDate(item.dueDate).toLocaleDateString()}
-                          </Badge>
-                        </div>
-                        {item.completionPercentage !== undefined && (
-                          <Progress value={item.completionPercentage} className="h-1" />
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </ScrollArea>
-              )}
-              {/* Legend */}
-              <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <FolderOpen className="h-3.5 w-3.5" /> Project
-                </span>
-                <span className="flex items-center gap-1">
-                  <FileText className="h-3.5 w-3.5" /> Action
-                </span>
-              </div>
-            </CardContent>
-          </Card>
+          <UpcomingDeadlinesCard
+            projects={projects}
+            actions={actions}
+            onSelectProject={onSelectProject}
+            onSelectAction={onSelectAction}
+          />
 
           {/* Enhanced Habit Consistency */}
           <Card>
@@ -779,20 +675,61 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
             </Card>
           )}
 
-          {/* Activity Summary - Placeholder for future implementation */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Clock className="h-5 w-5" />
-                Activity Summary
+                Recent Activity
               </CardTitle>
+              <CardDescription>Creates, updates, and completions across your workspace</CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 py-5 text-center text-sm text-muted-foreground">
-                <FileText className="h-8 w-8 mx-auto mb-2 text-muted-foreground/50" />
-                Recent activity is on the way
-                <p className="text-xs mt-1">Track creates, updates, and completions</p>
-              </div>
+              {recentActivity.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 py-5 text-center text-sm text-muted-foreground">
+                  <Activity className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+                  No recent activity in the last 30 days
+                </div>
+              ) : (
+                <ScrollArea className="h-[280px]">
+                  <div className="space-y-2 pr-3">
+                    {recentActivity.map((item) => {
+                      const ItemIcon = getActivityEntityIcon(item.entityType);
+
+                      return (
+                        <button
+                          type="button"
+                          key={item.id}
+                          className="flex w-full items-start gap-3 rounded-lg border border-border/70 p-3 text-left transition-colors hover:bg-accent/30"
+                          onClick={() => onSelectActivity?.(item)}
+                        >
+                          <div className="rounded-md border border-border/60 bg-muted/30 p-2">
+                            <ItemIcon className="h-4 w-4 text-muted-foreground" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <p className="truncate text-sm font-medium">{item.title}</p>
+                                {item.context && (
+                                  <p className="mt-1 text-xs text-muted-foreground">{item.context}</p>
+                                )}
+                              </div>
+                              <Badge
+                                variant="outline"
+                                className={cn('shrink-0 text-[11px] capitalize', getActivityBadgeClassName(item.activityType))}
+                              >
+                                {item.activityType}
+                              </Badge>
+                            </div>
+                            <p className="mt-2 text-xs text-muted-foreground">
+                              {formatRelativeDate(item.timestamp) || item.timestamp}
+                            </p>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/src/components/dashboard/HorizonRelationshipMap.tsx
+++ b/src/components/dashboard/HorizonRelationshipMap.tsx
@@ -5,18 +5,19 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import type { HorizonFile as HookHorizonFile } from '@/hooks/useHorizonsRelationships';
+import { norm } from '@/utils/path';
 import { Layers3, Link2, Network, Sparkles, Waypoints } from 'lucide-react';
 
-type HorizonGraph = {
+interface HorizonGraph {
   nodes: Array<{ id: string; label: string; level: string; group: number }>;
   edges: Array<{ from: string; to: string }>;
-};
+}
 
-type RelatedFiles = {
+interface RelatedFiles {
   parents: HookHorizonFile[];
   children: HookHorizonFile[];
   siblings: HookHorizonFile[];
-};
+}
 
 interface HorizonRelationshipMapProps {
   allFilesByLevel: Record<string, HookHorizonFile[]>;
@@ -76,6 +77,14 @@ const truncateLabel = (value: string, max = 24): string =>
   value.length > max ? `${value.slice(0, max - 1)}…` : value;
 
 const isActivationKey = (key: string): boolean => key === 'Enter' || key === ' ';
+const normalizePathKey = (value?: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = norm(value);
+  return typeof normalized === 'string' ? normalized : value;
+};
 
 const sortFiles = (files: HookHorizonFile[] = []): HookHorizonFile[] =>
   [...files].sort((a, b) => a.name.localeCompare(b.name));
@@ -84,7 +93,10 @@ const buildFileLookup = (filesByLevel: Record<string, HookHorizonFile[]>): Map<s
   const lookup = new Map<string, HookHorizonFile>();
   LEVEL_ORDER.forEach((level) => {
     (filesByLevel[level] ?? []).forEach((file) => {
-      lookup.set(file.path, file);
+      const normalizedPath = normalizePathKey(file.path);
+      if (normalizedPath) {
+        lookup.set(normalizedPath, file);
+      }
     });
   });
   return lookup;
@@ -114,7 +126,8 @@ const renderInspectorSection = (
             variant="ghost"
             className="h-auto w-full justify-start rounded-lg border border-border/50 px-3 py-2 text-left"
             onClick={() => {
-              if (visiblePaths.has(item.path)) {
+              const normalizedItemPath = normalizePathKey(item.path);
+              if (normalizedItemPath && visiblePaths.has(normalizedItemPath)) {
                 onSelectNode?.(item.path);
               }
               onOpenFile?.(item);
@@ -143,18 +156,40 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
 }) => {
   const allLookup = React.useMemo(() => buildFileLookup(allFilesByLevel), [allFilesByLevel]);
   const visibleLookup = React.useMemo(() => buildFileLookup(visibleFilesByLevel), [visibleFilesByLevel]);
+  const normalizedSelectedNodePath = React.useMemo(
+    () => normalizePathKey(selectedNodePath),
+    [selectedNodePath]
+  );
 
   const allPaths = React.useMemo(() => new Set(allLookup.keys()), [allLookup]);
   const visiblePaths = React.useMemo(() => new Set(visibleLookup.keys()), [visibleLookup]);
+  const visibleSelectedNodePath = React.useMemo(
+    () =>
+      normalizedSelectedNodePath && visiblePaths.has(normalizedSelectedNodePath)
+        ? normalizedSelectedNodePath
+        : null,
+    [normalizedSelectedNodePath, visiblePaths]
+  );
+
+  const normalizedEdges = React.useMemo(
+    () =>
+      graph.edges
+        .map((edge) => ({
+          from: normalizePathKey(edge.from),
+          to: normalizePathKey(edge.to),
+        }))
+        .filter((edge): edge is { from: string; to: string } => !!edge.from && !!edge.to),
+    [graph.edges]
+  );
 
   const allEdges = React.useMemo(
-    () => graph.edges.filter((edge) => allPaths.has(edge.from) && allPaths.has(edge.to)),
-    [allPaths, graph.edges]
+    () => normalizedEdges.filter((edge) => allPaths.has(edge.from) && allPaths.has(edge.to)),
+    [allPaths, normalizedEdges]
   );
 
   const visibleEdges = React.useMemo(
-    () => graph.edges.filter((edge) => visiblePaths.has(edge.from) && visiblePaths.has(edge.to)),
-    [graph.edges, visiblePaths]
+    () => normalizedEdges.filter((edge) => visiblePaths.has(edge.from) && visiblePaths.has(edge.to)),
+    [normalizedEdges, visiblePaths]
   );
 
   const positions = React.useMemo(() => {
@@ -169,11 +204,14 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
       const columnHeight = Math.max(files.length - 1, 0) * ROW_GAP;
       const offsetY = PADDING_Y + ((maxRows - 1) * ROW_GAP - columnHeight) / 2;
       files.forEach((file, rowIndex) => {
-        next.set(file.path, {
-          x: PADDING_X + columnIndex * COLUMN_WIDTH + COLUMN_WIDTH / 2,
-          y: offsetY + rowIndex * ROW_GAP,
-          level,
-        });
+        const normalizedPath = normalizePathKey(file.path);
+        if (normalizedPath) {
+          next.set(normalizedPath, {
+            x: PADDING_X + columnIndex * COLUMN_WIDTH + COLUMN_WIDTH / 2,
+            y: offsetY + rowIndex * ROW_GAP,
+            level,
+          });
+        }
       });
     });
 
@@ -187,8 +225,8 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
   const svgWidth = PADDING_X * 2 + LEVEL_ORDER.length * COLUMN_WIDTH;
   const svgHeight = Math.max(340, PADDING_Y * 2 + NODE_HEIGHT + Math.max(maxRows - 1, 0) * ROW_GAP);
 
-  const selectedFile = selectedNodePath ? allLookup.get(selectedNodePath) ?? null : null;
-  const related = selectedNodePath && findRelated ? findRelated(selectedNodePath) : null;
+  const selectedFile = normalizedSelectedNodePath ? allLookup.get(normalizedSelectedNodePath) ?? null : null;
+  const related = normalizedSelectedNodePath && findRelated ? findRelated(normalizedSelectedNodePath) : null;
 
   if (allEdges.length === 0) {
     return (
@@ -315,8 +353,8 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
                   }
 
                   const isSelectedEdge =
-                    selectedNodePath != null &&
-                    (edge.from === selectedNodePath || edge.to === selectedNodePath);
+                    visibleSelectedNodePath != null &&
+                    (edge.from === visibleSelectedNodePath || edge.to === visibleSelectedNodePath);
                   const touchesFocusedLevel =
                     selectedLevel === 'All' ||
                     from.level === selectedLevel ||
@@ -332,7 +370,7 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
                       d={`M ${startX} ${from.y} C ${startX + (leftToRight ? controlOffset : -controlOffset)} ${from.y}, ${endX - (leftToRight ? controlOffset : -controlOffset)} ${to.y}, ${endX} ${to.y}`}
                       fill="none"
                       stroke={isSelectedEdge ? '#38bdf8' : '#64748b'}
-                      strokeOpacity={selectedNodePath ? (isSelectedEdge ? 0.9 : 0.12) : (touchesFocusedLevel ? 0.44 : 0.14)}
+                      strokeOpacity={visibleSelectedNodePath ? (isSelectedEdge ? 0.9 : 0.12) : (touchesFocusedLevel ? 0.44 : 0.14)}
                       strokeWidth={isSelectedEdge ? 3 : 1.5}
                     />
                   );
@@ -341,18 +379,23 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
                 {LEVEL_ORDER.flatMap((level) => {
                   const meta = LEVEL_META[level];
                   return sortFiles(visibleFilesByLevel[level]).map((file) => {
-                    const position = positions.get(file.path);
+                    const normalizedFilePath = normalizePathKey(file.path);
+                    if (!normalizedFilePath) {
+                      return null;
+                    }
+
+                    const position = positions.get(normalizedFilePath);
                     if (!position) {
                       return null;
                     }
 
-                    const isSelected = selectedNodePath === file.path;
+                    const isSelected = visibleSelectedNodePath === normalizedFilePath;
                     const isConnected =
-                      !!selectedNodePath &&
+                      !!visibleSelectedNodePath &&
                       visibleEdges.some(
                         (edge) =>
-                          (edge.from === selectedNodePath && edge.to === file.path) ||
-                          (edge.to === selectedNodePath && edge.from === file.path)
+                          (edge.from === visibleSelectedNodePath && edge.to === normalizedFilePath) ||
+                          (edge.to === visibleSelectedNodePath && edge.from === normalizedFilePath)
                       );
                     const dimmed = selectedLevel !== 'All' && selectedLevel !== level;
                     const fill = isSelected
@@ -391,7 +434,7 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
                           height={NODE_HEIGHT}
                           rx={14}
                           fill={fill}
-                          opacity={selectedNodePath ? (isSelected || isConnected ? 1 : 0.68) : (dimmed ? 0.52 : 0.95)}
+                          opacity={visibleSelectedNodePath ? (isSelected || isConnected ? 1 : 0.68) : (dimmed ? 0.52 : 0.95)}
                           stroke={stroke}
                           strokeWidth={isSelected ? 2.5 : 1.2}
                         />
@@ -402,7 +445,7 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
                           fontSize="12.5"
                           fontWeight={isSelected ? '700' : '600'}
                           fill={isSelected ? 'hsl(var(--background))' : 'hsl(var(--foreground))'}
-                          opacity={selectedNodePath ? (isSelected || isConnected ? 1 : 0.62) : (dimmed ? 0.58 : 0.92)}
+                          opacity={visibleSelectedNodePath ? (isSelected || isConnected ? 1 : 0.62) : (dimmed ? 0.58 : 0.92)}
                         >
                           {truncateLabel(file.name.replace(/\.(md|markdown)$/i, ''))}
                         </text>

--- a/src/components/dashboard/HorizonRelationshipMap.tsx
+++ b/src/components/dashboard/HorizonRelationshipMap.tsx
@@ -75,6 +75,8 @@ const ROW_GAP = 72;
 const truncateLabel = (value: string, max = 24): string =>
   value.length > max ? `${value.slice(0, max - 1)}…` : value;
 
+const isActivationKey = (key: string): boolean => key === 'Enter' || key === ' ';
+
 const sortFiles = (files: HookHorizonFile[] = []): HookHorizonFile[] =>
   [...files].sort((a, b) => a.name.localeCompare(b.name));
 
@@ -371,7 +373,16 @@ export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
                           onSelectNode?.(file.path);
                           onOpenFile?.(file);
                         }}
+                        onKeyDown={(event) => {
+                          if (!isActivationKey(event.key)) {
+                            return;
+                          }
+                          event.preventDefault();
+                          onSelectNode?.(file.path);
+                          onOpenFile?.(file);
+                        }}
                         role="button"
+                        tabIndex={0}
                       >
                         <rect
                           x={position.x - NODE_WIDTH / 2}

--- a/src/components/dashboard/HorizonRelationshipMap.tsx
+++ b/src/components/dashboard/HorizonRelationshipMap.tsx
@@ -1,0 +1,466 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import type { HorizonFile as HookHorizonFile } from '@/hooks/useHorizonsRelationships';
+import { Layers3, Link2, Network, Sparkles, Waypoints } from 'lucide-react';
+
+type HorizonGraph = {
+  nodes: Array<{ id: string; label: string; level: string; group: number }>;
+  edges: Array<{ from: string; to: string }>;
+};
+
+type RelatedFiles = {
+  parents: HookHorizonFile[];
+  children: HookHorizonFile[];
+  siblings: HookHorizonFile[];
+};
+
+interface HorizonRelationshipMapProps {
+  allFilesByLevel: Record<string, HookHorizonFile[]>;
+  visibleFilesByLevel: Record<string, HookHorizonFile[]>;
+  graph: HorizonGraph;
+  selectedLevel?: string;
+  selectedNodePath?: string | null;
+  findRelated?: (filePath: string) => RelatedFiles;
+  onSelectNode?: (filePath: string) => void;
+  onOpenFile?: (file: HookHorizonFile) => void;
+}
+
+const LEVEL_ORDER = [
+  'Purpose & Principles',
+  'Vision',
+  'Goals',
+  'Areas of Focus',
+  'Projects',
+] as const;
+
+const LEVEL_META: Record<string, { accent: string; fill: string; mutedFill: string }> = {
+  'Purpose & Principles': {
+    accent: '#a855f7',
+    fill: 'rgba(168, 85, 247, 0.18)',
+    mutedFill: 'rgba(168, 85, 247, 0.08)',
+  },
+  'Vision': {
+    accent: '#2563eb',
+    fill: 'rgba(37, 99, 235, 0.18)',
+    mutedFill: 'rgba(37, 99, 235, 0.08)',
+  },
+  'Goals': {
+    accent: '#16a34a',
+    fill: 'rgba(22, 163, 74, 0.18)',
+    mutedFill: 'rgba(22, 163, 74, 0.08)',
+  },
+  'Areas of Focus': {
+    accent: '#ea580c',
+    fill: 'rgba(234, 88, 12, 0.18)',
+    mutedFill: 'rgba(234, 88, 12, 0.08)',
+  },
+  'Projects': {
+    accent: '#dc2626',
+    fill: 'rgba(220, 38, 38, 0.18)',
+    mutedFill: 'rgba(220, 38, 38, 0.08)',
+  },
+};
+
+const NODE_WIDTH = 196;
+const NODE_HEIGHT = 44;
+const COLUMN_WIDTH = 252;
+const PADDING_X = 42;
+const PADDING_Y = 66;
+const ROW_GAP = 72;
+
+const truncateLabel = (value: string, max = 24): string =>
+  value.length > max ? `${value.slice(0, max - 1)}…` : value;
+
+const sortFiles = (files: HookHorizonFile[] = []): HookHorizonFile[] =>
+  [...files].sort((a, b) => a.name.localeCompare(b.name));
+
+const buildFileLookup = (filesByLevel: Record<string, HookHorizonFile[]>): Map<string, HookHorizonFile> => {
+  const lookup = new Map<string, HookHorizonFile>();
+  LEVEL_ORDER.forEach((level) => {
+    (filesByLevel[level] ?? []).forEach((file) => {
+      lookup.set(file.path, file);
+    });
+  });
+  return lookup;
+};
+
+const renderInspectorSection = (
+  label: string,
+  items: HookHorizonFile[],
+  visiblePaths: Set<string>,
+  onSelectNode?: (filePath: string) => void,
+  onOpenFile?: (file: HookHorizonFile) => void
+) => (
+  <div className="space-y-2">
+    <div className="flex items-center justify-between">
+      <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+        {label}
+      </p>
+      <Badge variant="outline">{items.length}</Badge>
+    </div>
+    {items.length === 0 ? (
+      <p className="text-sm text-muted-foreground">None</p>
+    ) : (
+      <div className="space-y-2">
+        {items.map((item) => (
+          <Button
+            key={`${label}-${item.path}`}
+            variant="ghost"
+            className="h-auto w-full justify-start rounded-lg border border-border/50 px-3 py-2 text-left"
+            onClick={() => {
+              if (visiblePaths.has(item.path)) {
+                onSelectNode?.(item.path);
+              }
+              onOpenFile?.(item);
+            }}
+          >
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">{item.name.replace(/\.(md|markdown)$/i, '')}</div>
+              <div className="truncate text-xs text-muted-foreground">{item.horizonLevel}</div>
+            </div>
+          </Button>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+export const HorizonRelationshipMap: React.FC<HorizonRelationshipMapProps> = ({
+  allFilesByLevel,
+  visibleFilesByLevel,
+  graph,
+  selectedLevel = 'All',
+  selectedNodePath,
+  findRelated,
+  onSelectNode,
+  onOpenFile,
+}) => {
+  const allLookup = React.useMemo(() => buildFileLookup(allFilesByLevel), [allFilesByLevel]);
+  const visibleLookup = React.useMemo(() => buildFileLookup(visibleFilesByLevel), [visibleFilesByLevel]);
+
+  const allPaths = React.useMemo(() => new Set(allLookup.keys()), [allLookup]);
+  const visiblePaths = React.useMemo(() => new Set(visibleLookup.keys()), [visibleLookup]);
+
+  const allEdges = React.useMemo(
+    () => graph.edges.filter((edge) => allPaths.has(edge.from) && allPaths.has(edge.to)),
+    [allPaths, graph.edges]
+  );
+
+  const visibleEdges = React.useMemo(
+    () => graph.edges.filter((edge) => visiblePaths.has(edge.from) && visiblePaths.has(edge.to)),
+    [graph.edges, visiblePaths]
+  );
+
+  const positions = React.useMemo(() => {
+    const next = new Map<string, { x: number; y: number; level: string }>();
+    const maxRows = Math.max(
+      ...LEVEL_ORDER.map((level) => Math.max(sortFiles(visibleFilesByLevel[level]).length, 1)),
+      1
+    );
+
+    LEVEL_ORDER.forEach((level, columnIndex) => {
+      const files = sortFiles(visibleFilesByLevel[level]);
+      const columnHeight = Math.max(files.length - 1, 0) * ROW_GAP;
+      const offsetY = PADDING_Y + ((maxRows - 1) * ROW_GAP - columnHeight) / 2;
+      files.forEach((file, rowIndex) => {
+        next.set(file.path, {
+          x: PADDING_X + columnIndex * COLUMN_WIDTH + COLUMN_WIDTH / 2,
+          y: offsetY + rowIndex * ROW_GAP,
+          level,
+        });
+      });
+    });
+
+    return next;
+  }, [visibleFilesByLevel]);
+
+  const maxRows = React.useMemo(
+    () => Math.max(...LEVEL_ORDER.map((level) => Math.max((visibleFilesByLevel[level] ?? []).length, 1)), 1),
+    [visibleFilesByLevel]
+  );
+  const svgWidth = PADDING_X * 2 + LEVEL_ORDER.length * COLUMN_WIDTH;
+  const svgHeight = Math.max(340, PADDING_Y * 2 + NODE_HEIGHT + Math.max(maxRows - 1, 0) * ROW_GAP);
+
+  const selectedFile = selectedNodePath ? allLookup.get(selectedNodePath) ?? null : null;
+  const related = selectedNodePath && findRelated ? findRelated(selectedNodePath) : null;
+
+  if (allEdges.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Network className="h-5 w-5" />
+            Relationship Map
+          </CardTitle>
+          <CardDescription>Visual connections between your horizons</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex min-h-[260px] items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/20">
+            <div className="text-center">
+              <Layers3 className="mx-auto mb-3 h-10 w-10 text-muted-foreground/40" />
+              <p className="text-sm font-medium">No horizon relationships yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Add references between horizons to see the map populate.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (visibleEdges.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Network className="h-5 w-5" />
+            Relationship Map
+          </CardTitle>
+          <CardDescription>Visual connections between your horizons</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex min-h-[260px] items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/20">
+            <div className="text-center">
+              <Sparkles className="mx-auto mb-3 h-10 w-10 text-muted-foreground/40" />
+              <p className="text-sm font-medium">No relationships match the current filters</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Adjust search or filter settings to bring linked items back into view.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Network className="h-5 w-5" />
+              Relationship Map
+            </CardTitle>
+            <CardDescription>Visual connections between your horizons</CardDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{visibleEdges.length} links</Badge>
+            <Badge variant="outline">{visiblePaths.size} visible nodes</Badge>
+            {selectedLevel !== 'All' && (
+              <Badge variant="secondary">Focused on {selectedLevel}</Badge>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="rounded-xl border border-border/70 bg-card/50 p-3">
+            <div className="mb-4 flex flex-wrap items-center gap-2">
+              {LEVEL_ORDER.map((level) => {
+                const meta = LEVEL_META[level];
+                const muted = selectedLevel !== 'All' && selectedLevel !== level;
+                return (
+                  <div key={level} className={cn('flex items-center gap-2 text-xs', muted && 'opacity-50')}>
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: meta.accent }}
+                    />
+                    <span>{level}</span>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="overflow-x-auto">
+              <svg
+                aria-label="Horizon relationship map"
+                className="min-w-[1120px]"
+                viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+                role="img"
+              >
+                {LEVEL_ORDER.map((level, index) => {
+                  const columnX = PADDING_X + index * COLUMN_WIDTH + COLUMN_WIDTH / 2;
+                  const meta = LEVEL_META[level];
+                  const dimmed = selectedLevel !== 'All' && selectedLevel !== level;
+                  return (
+                    <g key={`column-${level}`}>
+                      <text
+                        x={columnX}
+                        y={28}
+                        textAnchor="middle"
+                        fontSize="13"
+                        fontWeight="700"
+                        fill={meta.accent}
+                        opacity={dimmed ? 0.38 : 0.92}
+                      >
+                        {level}
+                      </text>
+                    </g>
+                  );
+                })}
+
+                {visibleEdges.map((edge) => {
+                  const from = positions.get(edge.from);
+                  const to = positions.get(edge.to);
+                  if (!from || !to) {
+                    return null;
+                  }
+
+                  const isSelectedEdge =
+                    selectedNodePath != null &&
+                    (edge.from === selectedNodePath || edge.to === selectedNodePath);
+                  const touchesFocusedLevel =
+                    selectedLevel === 'All' ||
+                    from.level === selectedLevel ||
+                    to.level === selectedLevel;
+                  const leftToRight = from.x <= to.x;
+                  const startX = leftToRight ? from.x + NODE_WIDTH / 2 : from.x - NODE_WIDTH / 2;
+                  const endX = leftToRight ? to.x - NODE_WIDTH / 2 : to.x + NODE_WIDTH / 2;
+                  const controlOffset = Math.max(Math.abs(endX - startX) * 0.5, 72);
+
+                  return (
+                    <path
+                      key={`${edge.from}-${edge.to}`}
+                      d={`M ${startX} ${from.y} C ${startX + (leftToRight ? controlOffset : -controlOffset)} ${from.y}, ${endX - (leftToRight ? controlOffset : -controlOffset)} ${to.y}, ${endX} ${to.y}`}
+                      fill="none"
+                      stroke={isSelectedEdge ? '#38bdf8' : '#64748b'}
+                      strokeOpacity={selectedNodePath ? (isSelectedEdge ? 0.9 : 0.12) : (touchesFocusedLevel ? 0.44 : 0.14)}
+                      strokeWidth={isSelectedEdge ? 3 : 1.5}
+                    />
+                  );
+                })}
+
+                {LEVEL_ORDER.flatMap((level) => {
+                  const meta = LEVEL_META[level];
+                  return sortFiles(visibleFilesByLevel[level]).map((file) => {
+                    const position = positions.get(file.path);
+                    if (!position) {
+                      return null;
+                    }
+
+                    const isSelected = selectedNodePath === file.path;
+                    const isConnected =
+                      !!selectedNodePath &&
+                      visibleEdges.some(
+                        (edge) =>
+                          (edge.from === selectedNodePath && edge.to === file.path) ||
+                          (edge.to === selectedNodePath && edge.from === file.path)
+                      );
+                    const dimmed = selectedLevel !== 'All' && selectedLevel !== level;
+                    const fill = isSelected
+                      ? meta.accent
+                      : isConnected
+                        ? meta.fill
+                        : dimmed
+                          ? meta.mutedFill
+                          : 'hsl(var(--card))';
+                    const stroke = isSelected ? 'hsl(var(--background))' : meta.accent;
+
+                    return (
+                      <g
+                        key={file.path}
+                        aria-label={file.name.replace(/\.(md|markdown)$/i, '')}
+                        className="cursor-pointer"
+                        onClick={() => {
+                          onSelectNode?.(file.path);
+                          onOpenFile?.(file);
+                        }}
+                        role="button"
+                      >
+                        <rect
+                          x={position.x - NODE_WIDTH / 2}
+                          y={position.y - NODE_HEIGHT / 2}
+                          width={NODE_WIDTH}
+                          height={NODE_HEIGHT}
+                          rx={14}
+                          fill={fill}
+                          opacity={selectedNodePath ? (isSelected || isConnected ? 1 : 0.68) : (dimmed ? 0.52 : 0.95)}
+                          stroke={stroke}
+                          strokeWidth={isSelected ? 2.5 : 1.2}
+                        />
+                        <text
+                          x={position.x}
+                          y={position.y + 5}
+                          textAnchor="middle"
+                          fontSize="12.5"
+                          fontWeight={isSelected ? '700' : '600'}
+                          fill={isSelected ? 'hsl(var(--background))' : 'hsl(var(--foreground))'}
+                          opacity={selectedNodePath ? (isSelected || isConnected ? 1 : 0.62) : (dimmed ? 0.58 : 0.92)}
+                        >
+                          {truncateLabel(file.name.replace(/\.(md|markdown)$/i, ''))}
+                        </text>
+                      </g>
+                    );
+                  });
+                })}
+              </svg>
+            </div>
+          </div>
+
+          <Card className="border-border/70 bg-card/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Waypoints className="h-4 w-4" />
+                {selectedFile ? selectedFile.name.replace(/\.(md|markdown)$/i, '') : 'Inspector'}
+              </CardTitle>
+              <CardDescription>
+                {selectedFile
+                  ? `${selectedFile.horizonLevel} relationships`
+                  : 'Select a node to inspect parents, children, and siblings.'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {selectedFile && related ? (
+                <ScrollArea className="h-[360px] pr-4">
+                  <div className="space-y-5">
+                    <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <div>
+                          <p className="text-sm font-medium">{selectedFile.horizonLevel}</p>
+                          <p className="text-xs text-muted-foreground">{selectedFile.path}</p>
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => onOpenFile?.(selectedFile)}
+                        >
+                          <Link2 className="mr-2 h-3.5 w-3.5" />
+                          Open
+                        </Button>
+                      </div>
+                      {selectedFile.content && (
+                        <p className="mt-3 text-sm text-muted-foreground">{selectedFile.content}</p>
+                      )}
+                    </div>
+
+                    {renderInspectorSection('Parents', related.parents, visiblePaths, onSelectNode, onOpenFile)}
+                    {renderInspectorSection('Children', related.children, visiblePaths, onSelectNode, onOpenFile)}
+                    {renderInspectorSection('Siblings', related.siblings, visiblePaths, onSelectNode, onOpenFile)}
+                  </div>
+                </ScrollArea>
+              ) : (
+                <div className="flex min-h-[240px] items-center justify-center rounded-xl border border-dashed border-border/70 bg-muted/20 p-6 text-center">
+                  <div>
+                    <Layers3 className="mx-auto mb-3 h-10 w-10 text-muted-foreground/40" />
+                    <p className="text-sm font-medium">No node selected</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Click a node in the map to inspect its nearby relationships.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default HorizonRelationshipMap;

--- a/src/components/dashboard/UpcomingDeadlinesCard.tsx
+++ b/src/components/dashboard/UpcomingDeadlinesCard.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Switch } from '@/components/ui/switch';
+import type { ActionItem } from '@/hooks/useActionsData';
+import type { ProjectWithMetadata } from '@/hooks/useProjectsData';
+import { cn } from '@/lib/utils';
+import {
+  formatRelativeDate,
+  getDateFromNow,
+  isDateInRange,
+  isDateOverdue,
+  parseLocalDate,
+} from '@/utils/date-formatting';
+import { Calendar, FileText, FolderOpen } from 'lucide-react';
+
+type UpcomingDeadlineItem = {
+  id: string;
+  name: string;
+  type: 'project' | 'action';
+  dueDate: string;
+  completionPercentage?: number;
+};
+
+interface UpcomingDeadlinesCardProps {
+  projects: ProjectWithMetadata[];
+  actions: ActionItem[];
+  onSelectProject?: (path: string) => void;
+  onSelectAction?: (path: string) => void;
+}
+
+export function UpcomingDeadlinesCard({
+  projects,
+  actions,
+  onSelectProject,
+  onSelectAction,
+}: UpcomingDeadlinesCardProps) {
+  const [includeActions, setIncludeActions] = React.useState(true);
+  const [onlyOverdue, setOnlyOverdue] = React.useState(false);
+
+  const upcomingItems = React.useMemo(() => {
+    const now = new Date();
+    const weekFromNow = getDateFromNow(7);
+
+    const upcomingProjects: UpcomingDeadlineItem[] = projects
+      .filter((project) => {
+        if (!project.dueDate || project.status === 'completed' || project.status === 'cancelled') {
+          return false;
+        }
+        if (onlyOverdue) {
+          return isDateOverdue(project.dueDate);
+        }
+        return isDateInRange(project.dueDate, now, weekFromNow);
+      })
+      .map((project) => ({
+        id: project.path,
+        name: project.name,
+        type: 'project',
+        dueDate: project.dueDate!,
+        completionPercentage: project.completionPercentage,
+      }));
+
+    const upcomingActions: UpcomingDeadlineItem[] = actions
+      .filter((action) => {
+        if (!action.dueDate || action.status === 'completed' || action.status === 'cancelled') {
+          return false;
+        }
+        if (onlyOverdue) {
+          return isDateOverdue(action.dueDate);
+        }
+        return isDateInRange(action.dueDate, now, weekFromNow);
+      })
+      .map((action) => ({
+        id: action.path,
+        name: action.name,
+        type: 'action',
+        dueDate: action.dueDate!,
+      }));
+
+    return (includeActions ? [...upcomingProjects, ...upcomingActions] : upcomingProjects)
+      .sort((left, right) => parseLocalDate(left.dueDate).getTime() - parseLocalDate(right.dueDate).getTime())
+      .slice(0, 8);
+  }, [actions, includeActions, onlyOverdue, projects]);
+
+  return (
+    <Card className="border-border/70 shadow-sm">
+      <CardHeader className="space-y-4">
+        <div className="space-y-2">
+          <CardTitle className="flex items-center gap-3 text-2xl font-semibold leading-tight">
+            <Calendar className="h-5 w-5 shrink-0 text-muted-foreground" />
+            <span>Upcoming Deadlines</span>
+          </CardTitle>
+          <CardDescription>{onlyOverdue ? 'Overdue' : 'Next 7 days'}</CardDescription>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border/60 bg-muted/20 p-3">
+          <button
+            type="button"
+            className={cn(
+              'inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition-colors',
+              onlyOverdue
+                ? 'border-destructive/40 bg-destructive/10 text-destructive'
+                : 'border-border/70 text-muted-foreground hover:bg-accent'
+            )}
+            onClick={() => setOnlyOverdue((value) => !value)}
+            aria-pressed={onlyOverdue}
+          >
+            Only overdue
+          </button>
+
+          <div className="ml-auto flex items-center gap-2">
+            <span
+              id="upcoming-deadlines-include-actions"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Include actions
+            </span>
+            <Switch
+              checked={includeActions}
+              onCheckedChange={setIncludeActions}
+              aria-labelledby="upcoming-deadlines-include-actions"
+            />
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {upcomingItems.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 py-8 text-center text-sm text-muted-foreground">
+            {onlyOverdue ? 'No overdue items' : 'No upcoming deadlines this week'}
+          </div>
+        ) : (
+          <ScrollArea className="h-[240px]">
+            <div className="space-y-3 pr-3">
+              {upcomingItems.map((item) => {
+                const ItemIcon = item.type === 'project' ? FolderOpen : FileText;
+                const dueLabel =
+                  formatRelativeDate(item.dueDate) || parseLocalDate(item.dueDate).toLocaleDateString();
+
+                return (
+                  <div
+                    key={item.id}
+                    className="rounded-xl border border-border/70 bg-card/70 p-4 transition-colors hover:bg-accent/20"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => {
+                      if (item.type === 'action') {
+                        onSelectAction?.(item.id);
+                      } else {
+                        onSelectProject?.(item.id);
+                      }
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Enter' && event.key !== ' ') {
+                        return;
+                      }
+                      event.preventDefault();
+                      if (item.type === 'action') {
+                        onSelectAction?.(item.id);
+                      } else {
+                        onSelectProject?.(item.id);
+                      }
+                    }}
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 shrink-0 rounded-md border border-border/60 bg-muted/30 p-2">
+                        <ItemIcon className="h-4 w-4 text-muted-foreground" />
+                      </div>
+
+                      <div className="min-w-0 flex-1 space-y-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate text-base font-semibold leading-tight">{item.name}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {item.type === 'project' ? 'Project' : 'Action'}
+                            </p>
+                          </div>
+
+                          <Badge variant="outline" className="shrink-0 rounded-full px-3 py-1 text-xs">
+                            {dueLabel}
+                          </Badge>
+                        </div>
+
+                        {item.completionPercentage !== undefined && (
+                          <div className="space-y-1">
+                            <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                              <span>Project progress</span>
+                              <span>{item.completionPercentage}%</span>
+                            </div>
+                            <Progress value={item.completionPercentage} className="h-1.5" />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        )}
+
+        <div className="flex flex-wrap items-center gap-4 border-t border-border/60 pt-1 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <FolderOpen className="h-3.5 w-3.5" />
+            Project
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <FileText className="h-3.5 w-3.5" />
+            Action
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default UpcomingDeadlinesCard;

--- a/src/components/gtd/GTDDashboard.tsx
+++ b/src/components/gtd/GTDDashboard.tsx
@@ -22,8 +22,12 @@ import {
 } from '@/hooks/useProjectsData';
 import { useHabitsHistory } from '@/hooks/useHabitsHistory';
 import { useHorizonsRelationships } from '@/hooks/useHorizonsRelationships';
-import { useErrorHandler } from '@/hooks/useErrorHandler';
-import { GTDProjectDialog, GTDActionDialog } from '@/components/gtd';
+import {
+  GTDProjectDialog,
+  GTDActionDialog,
+  CreatePageDialog,
+  CreateHabitDialog,
+} from '@/components/gtd';
 import { safeInvoke } from '@/utils/safe-invoke';
 import { useToast } from '@/hooks/use-toast';
 import { ACTION_TOAST_DURATION_MS } from '@/hooks/use-toast';
@@ -41,9 +45,18 @@ import type { GTDActionStatus } from '@/types';
 import type { HorizonFile } from '@/hooks/useHorizonsRelationships';
 import { createScopedLogger } from '@/utils/logger';
 import { norm } from '@/utils/path';
-import { invoke } from '@tauri-apps/api/core';
+import { buildDashboardActivityFeed } from '@/utils/dashboard-activity';
 
 const log = createScopedLogger('GTDDashboard');
+
+type DashboardHorizonSectionId = 'purpose' | 'vision' | 'goals' | 'areas';
+
+type HorizonDialogConfig = {
+  directory: string;
+  directoryName: string;
+  sectionId: DashboardHorizonSectionId;
+  spacePath: string;
+};
 
 interface GTDDashboardProps {
   currentFolder: string | null;
@@ -101,9 +114,10 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
   const {
     horizons,
     relationships,
+    graph,
     isLoading: horizonsLoading,
     loadHorizons,
-    findRelated: _findRelated
+    findRelated
   } = useHorizonsRelationships({
     includeProjects: true,
     includeCabinet: true,
@@ -113,35 +127,51 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
   // State for UI management
   const [showProjectDialog, setShowProjectDialog] = React.useState(false);
   const [showActionDialog, setShowActionDialog] = React.useState(false);
+  const [showHabitDialog, setShowHabitDialog] = React.useState(false);
   const [selectedProject, setSelectedProject] = React.useState<GTDProject | null>(null);
+  const [pageDialogConfig, setPageDialogConfig] = React.useState<HorizonDialogConfig | null>(null);
   const [activeTab, setActiveTab] = React.useState('overview');
+  const [selectedHorizonLevel, setSelectedHorizonLevel] = React.useState<string>('All');
 
   // Track if we've loaded data for current space
   const loadedPathRef = React.useRef<string | null>(null);
   const { toast } = useToast();
-  const { withErrorHandling } = useErrorHandler();
 
-  // Helper function to sanitize file names for security
-  const sanitizeFileName = (input: string): string | null => {
-    if (!input || input.trim() === '') return null;
+  const openMarkdownFile = React.useCallback((filePath: string) => {
+    const normalizedPath = norm(filePath) ?? filePath;
+    const derivedName =
+      normalizedPath.split('/').filter(Boolean).pop() || 'Untitled.md';
 
-    // Remove path traversal attempts and dangerous characters
-    let sanitized = input
-      .replace(/\.\.[/\\]/g, '') // Remove ../
-      .replace(/[/\\]/g, '-')     // Replace path separators with hyphens
-      .replace(/[^a-zA-Z0-9\s\-_]/g, '') // Keep only safe characters
-      .trim();
+    onSelectFile?.({
+      id: normalizedPath,
+      name: derivedName,
+      path: normalizedPath,
+      size: 0,
+      last_modified: Math.floor(Date.now() / 1000),
+      extension: derivedName.split('.').pop() || 'md',
+    });
+  }, [onSelectFile]);
 
-    // Reject if empty after sanitization
-    if (!sanitized) return null;
+  const openProjectReadme = React.useCallback((projectPath: string) => {
+    onSelectProject(projectPath);
 
-    // Limit length
-    if (sanitized.length > 100) {
-      sanitized = sanitized.substring(0, 100);
-    }
+    const candidates = [
+      `${projectPath}/README.md`,
+      `${projectPath}/README.markdown`,
+    ];
 
-    return sanitized;
-  };
+    void (async () => {
+      for (const candidate of candidates) {
+        const exists = await safeInvoke<boolean>('check_file_exists', { filePath: candidate }, false);
+        if (exists) {
+          openMarkdownFile(candidate);
+          return;
+        }
+      }
+
+      openMarkdownFile(candidates[0]);
+    })();
+  }, [onSelectProject, openMarkdownFile]);
 
   // Load initial data when GTD space root path changes
   React.useEffect(() => {
@@ -485,6 +515,55 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
     await updateProject(projectPath, updates);
   };
 
+  const handleOpenAction = React.useCallback((actionPath: string) => {
+    openMarkdownFile(actionPath);
+  }, [openMarkdownFile]);
+
+  const handleOpenHabit = React.useCallback((habitPath: string) => {
+    openMarkdownFile(habitPath);
+  }, [openMarkdownFile]);
+
+  const handleOpenHorizonDialog = React.useCallback((horizon: string) => {
+    const rootPath = gtdSpace?.root_path;
+    if (!rootPath) {
+      return;
+    }
+
+    const configs: Record<string, Omit<HorizonDialogConfig, 'spacePath'>> = {
+      'Purpose & Principles': {
+        directory: `${rootPath}/Purpose & Principles`,
+        directoryName: 'Purpose & Principles',
+        sectionId: 'purpose',
+      },
+      'Vision': {
+        directory: `${rootPath}/Vision`,
+        directoryName: 'Vision',
+        sectionId: 'vision',
+      },
+      'Goals': {
+        directory: `${rootPath}/Goals`,
+        directoryName: 'Goals',
+        sectionId: 'goals',
+      },
+      'Areas of Focus': {
+        directory: `${rootPath}/Areas of Focus`,
+        directoryName: 'Areas of Focus',
+        sectionId: 'areas',
+      },
+    };
+
+    const nextConfig = configs[horizon];
+    if (!nextConfig) {
+      log.warn('Unsupported horizon dialog request', { horizon });
+      return;
+    }
+
+    setPageDialogConfig({
+      ...nextConfig,
+      spacePath: rootPath,
+    });
+  }, [gtdSpace?.root_path]);
+
   // Convert horizons to the format expected by DashboardHorizons
   const horizonFiles = React.useMemo(() => {
     const files: Record<string, HorizonFile[]> = {};
@@ -493,6 +572,15 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
     });
     return files;
   }, [horizons]);
+
+  const recentActivity = React.useMemo(() => (
+    buildDashboardActivityFeed({
+      actions,
+      projects: projectsWithMetadata,
+      habits: habitsWithHistory,
+      horizonFiles: Object.values(horizonFiles).flat(),
+    })
+  ), [actions, habitsWithHistory, horizonFiles, projectsWithMetadata]);
 
   if (!currentFolder || !gtdSpace?.isGTDSpace) {
     return (
@@ -564,27 +652,21 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
               horizonCounts={Object.fromEntries(
                 Object.entries(horizons).map(([name, level]) => [name, level.files.length])
               )}
+              recentActivity={recentActivity}
               isLoading={combinedLoading}
               onNewProject={() => setShowProjectDialog(true)}
-              onSelectProject={onSelectProject}
+              onSelectProject={openProjectReadme}
               onSelectHorizon={(name) => {
-                const level = horizons[name];
-                if (level && level.files.length > 0 && onSelectFile) {
-                  onSelectFile(level.files[0]);
-                }
+                setActiveTab('horizons');
+                setSelectedHorizonLevel(name);
               }}
-              onSelectAction={(actionPath) => {
-                if (onSelectFile) {
-                  const name = actionPath.split('/').pop() || 'Action.md';
-                  onSelectFile({
-                    id: actionPath,
-                    name,
-                    path: actionPath,
-                    size: 0,
-                    last_modified: Math.floor(Date.now() / 1000),
-                    extension: 'md'
-                  });
+              onSelectAction={handleOpenAction}
+              onSelectActivity={(item) => {
+                if (item.entityType === 'project') {
+                  openProjectReadme(item.path);
+                  return;
                 }
+                openMarkdownFile(item.path);
               }}
             />
           </TabsContent>
@@ -595,14 +677,7 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
               actions={actions}
               projects={gtdSpace.projects?.map(p => ({ name: p.name, path: p.path })) || []}
               isLoading={actionsLoading}
-              onSelectAction={(action) => onSelectFile?.({
-                id: action.id,
-                name: action.name,
-                path: action.path,
-                size: 0,
-                last_modified: Math.floor(Date.now() / 1000),
-                extension: 'md'
-              })}
+              onSelectAction={(action) => handleOpenAction(action.path)}
               onUpdateStatus={handleActionStatusUpdate}
               onBulkUpdate={handleBulkActionUpdate}
               onDeleteAction={handleDeleteAction}
@@ -615,33 +690,11 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
               projects={projectsWithMetadata}
               isLoading={projectsLoading}
               onSelectProject={(project) => {
-                onSelectProject(project.path);
-                if (onSelectFile) {
-                  const readmeFile: MarkdownFile = {
-                    id: `${project.path}/README.md`,
-                    name: 'README.md',
-                    path: `${project.path}/README.md`,
-                    size: 0,
-                    last_modified: Math.floor(Date.now() / 1000),
-                    extension: 'md'
-                  };
-                  onSelectFile(readmeFile);
-                }
+                void openProjectReadme(project.path);
               }}
               onCreateProject={() => setShowProjectDialog(true)}
               onEditProject={(project) => {
-                // Open the project's README file in the editor
-                if (onSelectFile) {
-                  const readmeFile: MarkdownFile = {
-                    id: `${project.path}/README.md`,
-                    name: 'README.md',
-                    path: `${project.path}/README.md`,
-                    size: 0,
-                    last_modified: Math.floor(Date.now() / 1000),
-                    extension: 'md'
-                  };
-                  onSelectFile(readmeFile);
-                }
+                void openProjectReadme(project.path);
               }}
               onCompleteProject={async (project) => {
                 await handleProjectUpdate(project.path, { status: 'completed' });
@@ -660,109 +713,9 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
               isLoading={habitsLoading}
               onToggleHabit={handleHabitToggle}
               onEditHabit={(habit) => {
-                if (onSelectFile) {
-                  onSelectFile({
-                    id: habit.path,
-                    name: habit.name,
-                    path: habit.path,
-                    size: 0,
-                    last_modified: Math.floor(Date.now() / 1000),
-                    extension: 'md'
-                  });
-                }
+                handleOpenHabit(habit.path);
               }}
-              onCreateHabit={async () => {
-                // Create a new habit file using the backend command
-                if (gtdSpace?.root_path) {
-                  const habitName = prompt('Enter habit name:');
-                  if (habitName) {
-                    const sanitizedHabitName = sanitizeFileName(habitName);
-                    if (!sanitizedHabitName) {
-                      toast({
-                        title: 'Invalid habit name',
-                        description: 'Please enter a valid habit name without special characters',
-                        variant: 'destructive'
-                      });
-                      return;
-                    }
-
-                    // Available frequencies: daily, weekdays, every-other-day, twice-weekly, weekly, biweekly, monthly
-                    const frequencyOptions = [
-                      { value: '5-minute', label: 'Every 5 Minutes (Testing)' },
-                      { value: 'daily', label: 'Daily' },
-                      { value: 'weekdays', label: 'Weekdays (Mon-Fri)' },
-                      { value: 'every-other-day', label: 'Every Other Day' },
-                      { value: 'twice-weekly', label: 'Twice a Week' },
-                      { value: 'weekly', label: 'Weekly' },
-                      { value: 'biweekly', label: 'Biweekly' },
-                      { value: 'monthly', label: 'Monthly' }
-                    ];
-
-                    const frequencyLabels = frequencyOptions.map(f => f.label).join('\n');
-                    const selectedLabel = prompt(`Select frequency:\n${frequencyLabels}`, 'Daily');
-
-                    if (selectedLabel) {
-                      const normalizedSelection = selectedLabel.trim().toLowerCase();
-                      const selectedFrequency = frequencyOptions.find(
-                        (f) =>
-                          f.label.trim().toLowerCase() === normalizedSelection ||
-                          f.value.trim().toLowerCase() === normalizedSelection
-                      );
-
-                      if (!selectedFrequency) {
-                        toast({
-                          title: 'Invalid frequency',
-                          description: 'Please choose one of the listed frequency options.',
-                          variant: 'destructive'
-                        });
-                        return;
-                      }
-
-                      const frequency = selectedFrequency.value;
-
-                      const habitPath = await withErrorHandling(async () => {
-                        const createdPath = await invoke<string>('create_gtd_habit', {
-                          spacePath: gtdSpace.root_path,
-                          habitName: sanitizedHabitName,
-                          frequency,
-                          focusTime: null
-                        });
-                        return createdPath;
-                      }, 'Failed to create habit');
-                      if (!habitPath) {
-                        return;
-                      }
-
-                      try {
-                        // Open the new habit file
-                        if (onSelectFile) {
-                          const normalizedHabitPath = norm(habitPath) ?? habitPath;
-                          const habitBaseName =
-                            normalizedHabitPath.split('/').filter(Boolean).pop() ||
-                            `${sanitizedHabitName}.md`;
-                          onSelectFile({
-                            id: normalizedHabitPath,
-                            name: habitBaseName,
-                            path: normalizedHabitPath,
-                            size: 0,
-                            last_modified: Math.floor(Date.now() / 1000),
-                            extension: 'md'
-                          });
-                        }
-                        // Reload habits
-                        await loadHabits(gtdSpace.root_path);
-                      } catch (error) {
-                        log.error('Failed to reload habits or select created habit', error);
-                        toast({
-                          title: 'Reloading habits or file selection failed',
-                          description: String(error),
-                          variant: 'destructive',
-                        });
-                      }
-                    }
-                  }
-                }
-              }}
+              onCreateHabit={() => setShowHabitDialog(true)}
             />
           </TabsContent>
 
@@ -772,85 +725,13 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
               horizonFiles={horizonFiles}
               projects={projectsWithMetadata}
               relationships={relationships}
+              graph={graph}
+              findRelated={findRelated}
+              selectedLevel={selectedHorizonLevel}
+              onSelectedLevelChange={setSelectedHorizonLevel}
               isLoading={horizonsLoading}
               onSelectFile={onSelectFile}
-              onCreateFile={async (horizon) => {
-                // Create a new file in the specified horizon
-                if (gtdSpace?.root_path) {
-                  const fileName = prompt(`Create new ${horizon} file:`);
-                  const sanitizedName = sanitizeFileName(fileName || '');
-
-                  if (!sanitizedName) {
-                    toast({
-                      title: 'Invalid file name',
-                      description: 'Please enter a valid file name without special characters',
-                      variant: 'destructive'
-                    });
-                    return;
-                  }
-
-                  // Ensure the file name ends with .md
-                  const fileNameWithExt = sanitizedName.endsWith('.md') ? sanitizedName : `${sanitizedName}.md`;
-                  const filePath = `${gtdSpace.root_path}/${horizon}/${fileNameWithExt}`;
-
-                  // Additional security check: ensure the resolved path is within the horizon directory
-                  const expectedPrefix = `${gtdSpace.root_path}/${horizon}/`;
-                  if (!filePath.startsWith(expectedPrefix)) {
-                    toast({
-                      title: 'Security error',
-                      description: 'Invalid file path detected',
-                      variant: 'destructive'
-                    });
-                    return;
-                  }
-
-                  const title = sanitizedName.replace('.md', '');
-
-                    // Create default content based on horizon type
-                    let defaultContent = `# ${title}\n\n`;
-
-                    // Add horizon-specific metadata fields
-                    if (horizon === 'Projects') {
-                      defaultContent += `[!singleselect:project-status:in-progress]\n[!datetime:due_date:]\n\n## Overview\n\n## Actions\n[!actions-list]\n`;
-                    } else if (horizon === 'Areas of Focus') {
-                      defaultContent += `## Description\n\n## Related Projects\n[!projects-references:]\n`;
-                    } else if (horizon === 'Goals') {
-                      defaultContent += `[!datetime:target_date:]\n\n## Objective\n\n## Related Areas\n[!areas-references:]\n`;
-                    } else if (horizon === 'Vision') {
-                      defaultContent += `## Vision Statement\n\n## Related Goals\n[!goals-references:]\n`;
-                    } else if (horizon === 'Purpose & Principles') {
-                      defaultContent += `## Core Purpose\n\n## Guiding Principles\n\n`;
-                    } else {
-                      defaultContent += `## Description\n\n`;
-                    }
-
-                    try {
-                      const writeResult = await safeInvoke('save_file', {
-                        path: filePath,
-                        content: defaultContent
-                      }, null);
-                      if (!writeResult) {
-                        log.error('Failed to create new file');
-                        return;
-                      }
-                      // Open the new file
-                      if (onSelectFile) {
-                        onSelectFile({
-                          id: filePath,
-                          name: fileNameWithExt,
-                          path: filePath,
-                          size: 0,
-                          last_modified: Math.floor(Date.now() / 1000),
-                          extension: 'md'
-                        });
-                      }
-                      // Reload horizons
-                      await loadHorizons(gtdSpace.root_path, gtdSpace.projects || []);
-                    } catch (error) {
-                      log.error('Failed to create file', error);
-                    }
-                  }
-              }}
+              onCreateFile={handleOpenHorizonDialog}
             />
           </TabsContent>
         </div>
@@ -865,6 +746,36 @@ const GTDDashboardComponent: React.FC<GTDDashboardProps> = ({
             spacePath={gtdSpace?.root_path || currentFolder || ''}
             onSuccess={() => loadProjects(currentFolder)}
           />
+
+          <CreateHabitDialog
+            isOpen={showHabitDialog}
+            onClose={() => setShowHabitDialog(false)}
+            spacePath={gtdSpace?.root_path || currentFolder || ''}
+            onSuccess={(habitPath) => {
+              void (async () => {
+                await loadHabits(gtdSpace?.root_path || currentFolder || '');
+                openMarkdownFile(habitPath);
+              })();
+            }}
+          />
+
+          {pageDialogConfig && (
+            <CreatePageDialog
+              isOpen={pageDialogConfig !== null}
+              onClose={() => setPageDialogConfig(null)}
+              directory={pageDialogConfig.directory}
+              directoryName={pageDialogConfig.directoryName}
+              sectionId={pageDialogConfig.sectionId}
+              spacePath={pageDialogConfig.spacePath}
+              onSuccess={(filePath) => {
+                void (async () => {
+                  await loadHorizons(pageDialogConfig.spacePath, gtdSpace?.projects || []);
+                  openMarkdownFile(filePath);
+                  setPageDialogConfig(null);
+                })();
+              }}
+            />
+          )}
 
           {selectedProject && (
             <GTDActionDialog

--- a/src/hooks/useHorizonsRelationships.ts
+++ b/src/hooks/useHorizonsRelationships.ts
@@ -8,6 +8,7 @@ import { safeInvoke } from '@/utils/safe-invoke';
 import { extractMetadata, extractHorizonReferences as extractHorizonReferencesUtil } from '@/utils/metadata-extractor';
 import { readFileText } from './useFileManager';
 import type { GTDProject, MarkdownFile } from '@/types';
+import { toISOStringFromEpoch } from '@/utils/time';
 
 export interface HorizonFile extends MarkdownFile {
   horizonLevel: string;
@@ -17,6 +18,7 @@ export interface HorizonFile extends MarkdownFile {
   tags?: string[];
   status?: string;
   dueDate?: string;
+  createdDateTime?: string;
 }
 
 export interface HorizonRelationship {
@@ -363,7 +365,12 @@ export function useHorizonsRelationships(
                       content: project.description || extractContentPreview(content),
                       tags: Array.isArray(metadata.tags) ? metadata.tags : [],
                       status: project.status ?? deriveStatusForLevel('Projects', metadata),
-                      dueDate: project.dueDate || undefined
+                      dueDate: project.dueDate || undefined,
+                      createdDateTime:
+                        typeof (metadata as { createdDateTime?: unknown }).createdDateTime === 'string' &&
+                        (metadata as { createdDateTime: string }).createdDateTime.trim().length > 0
+                          ? (metadata as { createdDateTime: string }).createdDateTime.trim()
+                          : project.createdDateTime,
                     };
                     
                     return file;
@@ -426,7 +433,12 @@ export function useHorizonsRelationships(
                       content: extractContentPreview(content),
                       tags: Array.isArray(metadata.tags) ? metadata.tags : [],
                       status: derivedStatus,
-                      dueDate: derivedDueDate
+                      dueDate: derivedDueDate,
+                      createdDateTime:
+                        typeof (metadata as { createdDateTime?: unknown }).createdDateTime === 'string' &&
+                        (metadata as { createdDateTime: string }).createdDateTime.trim().length > 0
+                          ? (metadata as { createdDateTime: string }).createdDateTime.trim()
+                          : toISOStringFromEpoch(mdFile.last_modified),
                     };
                     
                     return file;

--- a/src/hooks/useHorizonsRelationships.ts
+++ b/src/hooks/useHorizonsRelationships.ts
@@ -86,6 +86,65 @@ const HORIZON_DIR_MAP: Record<HorizonReferenceKey, string> = {
 const ABSOLUTE_PATH_REGEX = /^(?:[A-Za-z]:\/|\/)/;
 const VALID_REFERENCE_KEYS: HorizonReferenceKey[] = ['projects', 'areas', 'goals', 'vision', 'purpose'];
 
+const toUnixTimestampSeconds = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? Math.floor(value / 1000) : Math.floor(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const numericValue = Number(trimmed);
+    if (Number.isFinite(numericValue)) {
+      return numericValue > 1_000_000_000_000
+        ? Math.floor(numericValue / 1000)
+        : Math.floor(numericValue);
+    }
+
+    const parsed = Date.parse(trimmed);
+    return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+  }
+
+  if (value instanceof Date) {
+    return Math.floor(value.getTime() / 1000);
+  }
+
+  return null;
+};
+
+const resolveProjectLastModified = (
+  metadata: Record<string, unknown>,
+  project: GTDProject
+): number => {
+  const metadataKeys: Array<keyof typeof metadata> = ['mtime', 'modified', 'last_modified'];
+
+  for (const key of metadataKeys) {
+    const resolved = toUnixTimestampSeconds(metadata[key]);
+    if (resolved !== null) {
+      return resolved;
+    }
+  }
+
+  const projectWithMetadata = project as GTDProject & {
+    modifiedDate?: string | number | Date;
+  };
+
+  const projectModified = toUnixTimestampSeconds(projectWithMetadata.modifiedDate);
+  if (projectModified !== null) {
+    return projectModified;
+  }
+
+  const projectCreated = toUnixTimestampSeconds(project.createdDateTime);
+  if (projectCreated !== null) {
+    return projectCreated;
+  }
+
+  return Math.floor(Date.now() / 1000);
+};
+
 const joinPathPreservingUNC = (base: string, ...segments: string[]): string => {
   let acc = base;
   segments.forEach((segment) => {
@@ -357,7 +416,7 @@ export function useHorizonsRelationships(
                       name: project.name,
                       path: readmePath,
                       size: 0,
-                      last_modified: Math.floor(Date.now() / 1000),
+                      last_modified: resolveProjectLastModified(metadata as Record<string, unknown>, project),
                       extension: 'md',
                       horizonLevel: 'Projects',
                       linkedTo: Array.from(linkedSet),

--- a/src/hooks/useProjectsData.ts
+++ b/src/hooks/useProjectsData.ts
@@ -199,6 +199,14 @@ const resolveProjectReadme = async (projectPath: string): Promise<string | null>
   return null;
 };
 
+const getProjectRootReadmeCandidates = (projectPath: string): string[] => {
+  const normalizedProjectPath = norm(projectPath) ?? projectPath;
+  return [
+    `${normalizedProjectPath}/README.md`,
+    `${normalizedProjectPath}/README.markdown`,
+  ];
+};
+
 const resolveProjectReadmeFile = async (projectPath: string): Promise<MarkdownFile | null> => {
   try {
     const files = await safeInvoke<MarkdownFile[]>(
@@ -206,10 +214,19 @@ const resolveProjectReadmeFile = async (projectPath: string): Promise<MarkdownFi
       { path: projectPath },
       []
     );
-    return files.find((file) => {
-      const normalizedFilePath = norm(file.path) ?? file.path;
-      return /\/README\.(md|markdown)$/i.test(normalizedFilePath);
-    }) ?? null;
+    const rootCandidates = getProjectRootReadmeCandidates(projectPath).map((candidate) => candidate.toLowerCase());
+    const fileMap = new Map<string, MarkdownFile>();
+
+    files.forEach((file) => {
+      const normalizedFilePath = (norm(file.path) ?? file.path).toLowerCase();
+      fileMap.set(normalizedFilePath, file);
+    });
+
+    return (
+      fileMap.get(rootCandidates[0]) ??
+      fileMap.get(rootCandidates[1]) ??
+      null
+    );
   } catch (error) {
     console.error('[resolveProjectReadmeFile] Failed to locate README metadata:', error);
     return null;

--- a/src/hooks/useProjectsData.ts
+++ b/src/hooks/useProjectsData.ts
@@ -93,6 +93,7 @@ const updateProjectDueDateInMarkdown = (content: string, dueDate: string): strin
 };
 
 export interface ProjectWithMetadata extends GTDProject {
+  modifiedDate?: string;
   linkedAreas?: string[];
   linkedGoals?: string[];
   linkedVision?: string[];
@@ -196,6 +197,23 @@ const resolveProjectReadme = async (projectPath: string): Promise<string | null>
   }
 
   return null;
+};
+
+const resolveProjectReadmeFile = async (projectPath: string): Promise<MarkdownFile | null> => {
+  try {
+    const files = await safeInvoke<MarkdownFile[]>(
+      'list_markdown_files',
+      { path: projectPath },
+      []
+    );
+    return files.find((file) => {
+      const normalizedFilePath = norm(file.path) ?? file.path;
+      return /\/README\.(md|markdown)$/i.test(normalizedFilePath);
+    }) ?? null;
+  } catch (error) {
+    console.error('[resolveProjectReadmeFile] Failed to locate README metadata:', error);
+    return null;
+  }
 };
 
 export function useProjectsData(options: UseProjectsDataOptions = {}): UseProjectsDataReturn {
@@ -316,9 +334,13 @@ export function useProjectsData(options: UseProjectsDataOptions = {}): UseProjec
       const enhancedProjects = await Promise.all(
         filteredProjects.map(async (project) => {
           try {
-            const readmePath = await resolveProjectReadme(project.path);
+            const readmeFile = await resolveProjectReadmeFile(project.path);
+            const readmePath = readmeFile?.path || await resolveProjectReadme(project.path);
             let parsedProject = null as ReturnType<typeof parseProjectMarkdown> | null;
             let outcomes: string[] = [];
+            const modifiedDate = readmeFile
+              ? toISOStringFromEpoch(readmeFile.last_modified)
+              : project.createdDateTime;
 
             if (readmePath) {
               const content = await readFileText(readmePath);
@@ -382,6 +404,7 @@ export function useProjectsData(options: UseProjectsDataOptions = {}): UseProjec
               linkedGoals: parsedProject?.horizonReferences.goals ?? [],
               linkedVision: parsedProject?.horizonReferences.vision ?? [],
               linkedPurpose: parsedProject?.horizonReferences.purpose ?? [],
+              modifiedDate,
               completionPercentage,
               actionStats,
               effort: undefined,
@@ -521,6 +544,7 @@ export function useProjectsData(options: UseProjectsDataOptions = {}): UseProjec
               : project.name,
           status: nextParsedProject.status,
           dueDate: nextParsedProject.dueDate || null,
+          modifiedDate: new Date().toISOString(),
         };
       }));
     } catch (err) {

--- a/src/hooks/useProjectsData.ts
+++ b/src/hooks/useProjectsData.ts
@@ -7,6 +7,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { safeInvoke } from '@/utils/safe-invoke';
 import { readFileText } from './useFileManager';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
+import type { UseErrorHandlerReturn } from '@/hooks/useErrorHandler';
 import type { GTDProject, MarkdownFile } from '@/types';
 import { toISOStringFromEpoch } from '@/utils/time';
 import { parseLocalDate } from '@/utils/date-formatting';
@@ -207,13 +208,24 @@ const getProjectRootReadmeCandidates = (projectPath: string): string[] => {
   ];
 };
 
-const resolveProjectReadmeFile = async (projectPath: string): Promise<MarkdownFile | null> => {
+type WithErrorHandling = UseErrorHandlerReturn['withErrorHandling'];
+
+const resolveProjectReadmeFile = async (
+  projectPath: string,
+  withErrorHandling: WithErrorHandling
+): Promise<MarkdownFile | null> => {
   try {
-    const files = await safeInvoke<MarkdownFile[]>(
-      'list_markdown_files',
-      { path: projectPath },
-      []
+    const files = await withErrorHandling(
+      () => safeInvoke<MarkdownFile[]>(
+        'list_markdown_files',
+        { path: projectPath },
+        []
+      ),
+      'Failed to locate project README metadata'
     );
+    if (!files) {
+      return null;
+    }
     const rootCandidates = getProjectRootReadmeCandidates(projectPath).map((candidate) => candidate.toLowerCase());
     const fileMap = new Map<string, MarkdownFile>();
 
@@ -351,7 +363,7 @@ export function useProjectsData(options: UseProjectsDataOptions = {}): UseProjec
       const enhancedProjects = await Promise.all(
         filteredProjects.map(async (project) => {
           try {
-            const readmeFile = await resolveProjectReadmeFile(project.path);
+            const readmeFile = await resolveProjectReadmeFile(project.path, withErrorHandling);
             const readmePath = readmeFile?.path || await resolveProjectReadme(project.path);
             let parsedProject = null as ReturnType<typeof parseProjectMarkdown> | null;
             let outcomes: string[] = [];
@@ -445,7 +457,7 @@ export function useProjectsData(options: UseProjectsDataOptions = {}): UseProjec
     } finally {
       setIsLoading(false);
     }
-  }, [includeArchived, loadActionStats]);
+  }, [includeArchived, loadActionStats, withErrorHandling]);
   
   const updateProject = useCallback(async (
     projectPath: string,

--- a/src/utils/dashboard-activity.ts
+++ b/src/utils/dashboard-activity.ts
@@ -1,0 +1,230 @@
+import type { ActionItem } from '@/hooks/useActionsData';
+import type { HabitWithHistory } from '@/hooks/useHabitsHistory';
+import type { ProjectWithMetadata } from '@/hooks/useProjectsData';
+import type { HorizonFile } from '@/hooks/useHorizonsRelationships';
+import { toISOStringFromEpoch } from '@/utils/time';
+
+export type DashboardActivityEntityType = 'project' | 'action' | 'habit' | 'horizon';
+export type DashboardActivityType = 'created' | 'updated' | 'completed';
+
+export interface DashboardActivityItem {
+  id: string;
+  entityType: DashboardActivityEntityType;
+  activityType: DashboardActivityType;
+  title: string;
+  path: string;
+  timestamp: string;
+  context?: string;
+  horizonLevel?: string;
+}
+
+type ActivityCandidate = DashboardActivityItem & {
+  timestampMs: number;
+};
+
+const MAX_ACTIVITY_ITEMS = 10;
+const RECENT_ACTIVITY_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+const parseTimestamp = (value?: string | null): number | null => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const parseHabitTimestamp = (date?: string, time?: string): number | null => {
+  if (!date) {
+    return null;
+  }
+
+  if (!time || !time.trim()) {
+    return Date.parse(`${date}T00:00:00`);
+  }
+
+  const trimmed = time.trim();
+  const twentyFourHourMatch = trimmed.match(/^(\d{1,2}):(\d{2})$/);
+  if (twentyFourHourMatch) {
+    const [, hours, minutes] = twentyFourHourMatch;
+    return Date.parse(`${date}T${hours.padStart(2, '0')}:${minutes}:00`);
+  }
+
+  const meridiemMatch = trimmed.match(/^(\d{1,2}):(\d{2})\s*([AP]M)$/i);
+  if (meridiemMatch) {
+    const [, rawHours, minutes, meridiem] = meridiemMatch;
+    let hours = Number(rawHours) % 12;
+    if (meridiem.toUpperCase() === 'PM') {
+      hours += 12;
+    }
+    return Date.parse(`${date}T${String(hours).padStart(2, '0')}:${minutes}:00`);
+  }
+
+  const fallback = Date.parse(`${date} ${trimmed}`);
+  return Number.isNaN(fallback) ? null : fallback;
+};
+
+const toRecentCandidate = (
+  item: Omit<ActivityCandidate, 'timestampMs'>,
+  timestampMs: number | null
+): ActivityCandidate | null => {
+  if (timestampMs === null || Number.isNaN(timestampMs)) {
+    return null;
+  }
+
+  if (Date.now() - timestampMs > RECENT_ACTIVITY_WINDOW_MS) {
+    return null;
+  }
+
+  return {
+    ...item,
+    timestampMs,
+  };
+};
+
+const buildActionActivity = (action: ActionItem): ActivityCandidate | null => {
+  const createdMs = parseTimestamp(action.createdDate);
+  const modifiedMs = parseTimestamp(action.modifiedDate) ?? createdMs;
+  const latestMs = modifiedMs ?? createdMs;
+
+  if (latestMs === null) {
+    return null;
+  }
+
+  const activityType: DashboardActivityType =
+    action.status === 'completed' && modifiedMs !== null
+      ? 'completed'
+      : modifiedMs !== null && createdMs !== null && modifiedMs > createdMs
+        ? 'updated'
+        : 'created';
+
+  return toRecentCandidate({
+    id: `action:${action.path}`,
+    entityType: 'action',
+    activityType,
+    title: action.name,
+    path: action.path,
+    timestamp: new Date(latestMs).toISOString(),
+    context: action.projectName ? `Action in ${action.projectName}` : 'Action',
+  }, latestMs);
+};
+
+const buildProjectActivity = (project: ProjectWithMetadata): ActivityCandidate | null => {
+  const createdMs = parseTimestamp(project.createdDateTime);
+  const modifiedMs = parseTimestamp(project.modifiedDate) ?? createdMs;
+  const latestMs = modifiedMs ?? createdMs;
+
+  if (latestMs === null) {
+    return null;
+  }
+
+  const activityType: DashboardActivityType =
+    project.status === 'completed' && modifiedMs !== null
+      ? 'completed'
+      : modifiedMs !== null && createdMs !== null && modifiedMs > createdMs
+        ? 'updated'
+        : 'created';
+
+  return toRecentCandidate({
+    id: `project:${project.path}`,
+    entityType: 'project',
+    activityType,
+    title: project.name,
+    path: project.path,
+    timestamp: new Date(latestMs).toISOString(),
+    context: 'Project',
+  }, latestMs);
+};
+
+const buildHabitActivity = (habit: HabitWithHistory): ActivityCandidate | null => {
+  const latestCompletionMs = habit.periodHistory
+    .filter((entry) => entry.completed)
+    .map((entry) => parseHabitTimestamp(entry.date, entry.time))
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => b - a)[0] ?? null;
+
+  if (latestCompletionMs !== null) {
+    return toRecentCandidate({
+      id: `habit:${habit.path}`,
+      entityType: 'habit',
+      activityType: 'completed',
+      title: habit.name,
+      path: habit.path,
+      timestamp: new Date(latestCompletionMs).toISOString(),
+      context: 'Habit',
+    }, latestCompletionMs);
+  }
+
+  const createdMs = parseTimestamp(habit.createdDateTime);
+  const updatedMs = parseTimestamp(habit.last_updated) ?? createdMs;
+  const latestMs = updatedMs ?? createdMs;
+
+  if (latestMs === null) {
+    return null;
+  }
+
+  const activityType: DashboardActivityType =
+    updatedMs !== null && createdMs !== null && updatedMs > createdMs
+      ? 'updated'
+      : 'created';
+
+  return toRecentCandidate({
+    id: `habit:${habit.path}`,
+    entityType: 'habit',
+    activityType,
+    title: habit.name,
+    path: habit.path,
+    timestamp: new Date(latestMs).toISOString(),
+    context: 'Habit',
+  }, latestMs);
+};
+
+const buildHorizonActivity = (file: HorizonFile): ActivityCandidate | null => {
+  const createdMs = parseTimestamp(file.createdDateTime);
+  const modifiedMs = typeof file.last_modified === 'number'
+    ? parseTimestamp(toISOStringFromEpoch(file.last_modified))
+    : null;
+  const latestMs = modifiedMs ?? createdMs;
+
+  if (latestMs === null) {
+    return null;
+  }
+
+  const displayTitle = file.name.replace(/\.(md|markdown)$/i, '');
+  const activityType: DashboardActivityType =
+    modifiedMs !== null && createdMs !== null && modifiedMs > createdMs
+      ? 'updated'
+      : 'created';
+
+  return toRecentCandidate({
+    id: `horizon:${file.path}`,
+    entityType: 'horizon',
+    activityType,
+    title: displayTitle,
+    path: file.path,
+    timestamp: new Date(latestMs).toISOString(),
+    context: file.horizonLevel,
+    horizonLevel: file.horizonLevel,
+  }, latestMs);
+};
+
+export const buildDashboardActivityFeed = (params: {
+  actions: ActionItem[];
+  projects: ProjectWithMetadata[];
+  habits: HabitWithHistory[];
+  horizonFiles: HorizonFile[];
+}): DashboardActivityItem[] => {
+  const items = [
+    ...params.actions.map(buildActionActivity),
+    ...params.projects.map(buildProjectActivity),
+    ...params.habits.map(buildHabitActivity),
+    ...params.horizonFiles
+      .filter((file) => file.horizonLevel !== 'Projects')
+      .map(buildHorizonActivity),
+  ]
+    .filter((item): item is ActivityCandidate => item !== null)
+    .sort((a, b) => b.timestampMs - a.timestampMs)
+    .slice(0, MAX_ACTIVITY_ITEMS);
+
+  return items.map(({ timestampMs: _timestampMs, ...item }) => item);
+};

--- a/tests/dashboard-activity.spec.ts
+++ b/tests/dashboard-activity.spec.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildDashboardActivityFeed } from '@/utils/dashboard-activity';
+import type { ActionItem } from '@/hooks/useActionsData';
+import type { HabitWithHistory } from '@/hooks/useHabitsHistory';
+import type { ProjectWithMetadata } from '@/hooks/useProjectsData';
+import type { HorizonFile } from '@/hooks/useHorizonsRelationships';
+
+const buildAction = (overrides: Partial<ActionItem> = {}): ActionItem => ({
+  id: '/space/Projects/Alpha/Actions/default.md',
+  name: 'Default Action',
+  path: '/space/Projects/Alpha/Actions/default.md',
+  projectName: 'Alpha',
+  projectPath: '/space/Projects/Alpha',
+  status: 'todo',
+  createdDate: '2026-03-29T09:00:00.000Z',
+  modifiedDate: '2026-03-29T09:00:00.000Z',
+  ...overrides,
+});
+
+const buildProject = (overrides: Partial<ProjectWithMetadata> = {}): ProjectWithMetadata => ({
+  id: '/space/Projects/Alpha',
+  name: 'Alpha',
+  path: '/space/Projects/Alpha',
+  status: 'in-progress',
+  description: 'Alpha project',
+  createdDateTime: '2026-03-28T09:00:00.000Z',
+  modifiedDate: '2026-03-28T09:00:00.000Z',
+  ...overrides,
+} as ProjectWithMetadata);
+
+const buildHabit = (overrides: Partial<HabitWithHistory> = {}): HabitWithHistory => ({
+  name: 'Stretch',
+  frequency: 'daily',
+  status: 'todo',
+  path: '/space/Habits/stretch.md',
+  createdDateTime: '2026-03-27T09:00:00.000Z',
+  last_updated: '2026-03-27T09:00:00.000Z',
+  history: [],
+  periodHistory: [],
+  currentStreak: 0,
+  bestStreak: 0,
+  averageStreak: 0,
+  successRate: 0,
+  totalCompletions: 0,
+  totalAttempts: 0,
+  recentTrend: 'stable',
+  linkedProjects: [],
+  linkedAreas: [],
+  linkedGoals: [],
+  linkedVision: [],
+  linkedPurpose: [],
+  ...overrides,
+});
+
+const buildHorizon = (overrides: Partial<HorizonFile> = {}): HorizonFile => ({
+  id: '/space/Goals/Quarter.md',
+  name: 'Quarter.md',
+  path: '/space/Goals/Quarter.md',
+  size: 0,
+  last_modified: Math.floor(Date.parse('2026-03-26T09:00:00.000Z') / 1000),
+  extension: 'md',
+  horizonLevel: 'Goals',
+  linkedTo: [],
+  linkedFrom: [],
+  createdDateTime: '2026-03-26T09:00:00.000Z',
+  ...overrides,
+});
+
+describe('buildDashboardActivityFeed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-31T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('classifies and sorts action, project, habit, and horizon activity by latest event', () => {
+    const feed = buildDashboardActivityFeed({
+      actions: [
+        buildAction({
+          name: 'Ship lesson',
+          status: 'completed',
+          modifiedDate: '2026-03-31T11:00:00.000Z',
+        }),
+      ],
+      projects: [
+        buildProject({
+          name: 'Beta',
+          modifiedDate: '2026-03-30T11:00:00.000Z',
+        }),
+      ],
+      habits: [
+        buildHabit({
+          name: 'Walk',
+          periodHistory: [{ date: '2026-03-29', time: '09:15', completed: true }],
+        }),
+      ],
+      horizonFiles: [
+        buildHorizon({
+          name: 'North Star.md',
+          path: '/space/Vision/North Star.md',
+          horizonLevel: 'Vision',
+          createdDateTime: '2026-03-28T10:00:00.000Z',
+          last_modified: Math.floor(Date.parse('2026-03-28T10:00:00.000Z') / 1000),
+        }),
+      ],
+    });
+
+    expect(feed).toHaveLength(4);
+    expect(feed.map((item) => item.title)).toEqual(['Ship lesson', 'Beta', 'Walk', 'North Star']);
+    expect(feed.map((item) => item.activityType)).toEqual(['completed', 'updated', 'completed', 'created']);
+  });
+
+  it('skips invalid or stale timestamps, excludes project horizon files, and caps the feed at ten rows', () => {
+    const manyActions = Array.from({ length: 12 }, (_, index) =>
+      buildAction({
+        id: `/space/Projects/Alpha/Actions/${index}.md`,
+        path: `/space/Projects/Alpha/Actions/${index}.md`,
+        name: `Action ${index}`,
+        createdDate: `2026-03-${String(20 + index).padStart(2, '0')}T09:00:00.000Z`,
+        modifiedDate: `2026-03-${String(20 + index).padStart(2, '0')}T10:00:00.000Z`,
+      })
+    );
+
+    const feed = buildDashboardActivityFeed({
+      actions: [
+        ...manyActions,
+        buildAction({
+          id: 'invalid',
+          path: 'invalid',
+          name: 'Broken timestamp',
+          createdDate: 'not-a-date',
+          modifiedDate: 'still-not-a-date',
+        }),
+        buildAction({
+          id: 'stale',
+          path: 'stale',
+          name: 'Too old',
+          createdDate: '2026-01-01T09:00:00.000Z',
+          modifiedDate: '2026-01-01T09:00:00.000Z',
+        }),
+      ],
+      projects: [],
+      habits: [],
+      horizonFiles: [
+        buildHorizon({
+          id: '/space/Projects/Alpha/README.md',
+          path: '/space/Projects/Alpha/README.md',
+          name: 'README.md',
+          horizonLevel: 'Projects',
+        }),
+      ],
+    });
+
+    expect(feed).toHaveLength(10);
+    expect(feed.some((item) => item.title === 'Broken timestamp')).toBe(false);
+    expect(feed.some((item) => item.title === 'Too old')).toBe(false);
+    expect(feed.some((item) => item.path === '/space/Projects/Alpha/README.md')).toBe(false);
+    expect(feed[0]?.title).toBe('Action 11');
+    expect(feed[9]?.title).toBe('Action 2');
+  });
+});

--- a/tests/dashboard-habits.component.spec.tsx
+++ b/tests/dashboard-habits.component.spec.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import DashboardHabits from '@/components/dashboard/DashboardHabits';
 import type { HabitWithHistory } from '@/hooks/useHabitsHistory';
@@ -29,6 +29,15 @@ const buildHabit = (overrides: Partial<HabitWithHistory> = {}): HabitWithHistory
 });
 
 describe('DashboardHabits', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-31T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the 5-minute frequency label on habit cards', () => {
     render(
       <DashboardHabits
@@ -68,5 +77,6 @@ describe('DashboardHabits', () => {
     expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByRole('tab', { name: 'History' })).toBeInTheDocument();
     expect(screen.getByText('Stretch')).toBeInTheDocument();
+    expect(screen.getByText('Reset: 5m')).toBeInTheDocument();
   });
 });

--- a/tests/dashboard-habits.component.spec.tsx
+++ b/tests/dashboard-habits.component.spec.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DashboardHabits from '@/components/dashboard/DashboardHabits';
+import type { HabitWithHistory } from '@/hooks/useHabitsHistory';
+
+const buildHabit = (overrides: Partial<HabitWithHistory> = {}): HabitWithHistory => ({
+  name: 'Default Habit',
+  frequency: 'daily',
+  status: 'todo',
+  path: '/space/Habits/default.md',
+  createdDateTime: '2026-01-01T08:00:00Z',
+  last_updated: '2026-03-31T08:00:00Z',
+  history: [],
+  periodHistory: [],
+  currentStreak: 1,
+  bestStreak: 2,
+  averageStreak: 1,
+  successRate: 75,
+  totalCompletions: 3,
+  totalAttempts: 4,
+  recentTrend: 'stable',
+  linkedProjects: [],
+  linkedAreas: [],
+  linkedGoals: [],
+  linkedVision: [],
+  linkedPurpose: [],
+  ...overrides,
+});
+
+describe('DashboardHabits', () => {
+  it('renders the 5-minute frequency label on habit cards', () => {
+    render(
+      <DashboardHabits
+        habits={[
+          buildHabit({
+            name: 'Stretch',
+            frequency: '5-minute',
+            path: '/space/Habits/stretch.md',
+          }),
+        ]}
+        onCreateHabit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Every 5 Minutes')).toBeInTheDocument();
+  });
+
+  it('keeps the history tab and frequency filter available for 5-minute habits', () => {
+    render(
+      <DashboardHabits
+        habits={[
+          buildHabit({
+            name: 'Stretch',
+            frequency: '5-minute',
+            path: '/space/Habits/stretch.md',
+          }),
+          buildHabit({
+            name: 'Read',
+            frequency: 'daily',
+            path: '/space/Habits/read.md',
+          }),
+        ]}
+        onCreateHabit={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('tab', { name: 'History' })).toBeInTheDocument();
+    expect(screen.getByText('Stretch')).toBeInTheDocument();
+  });
+});

--- a/tests/dashboard-horizons.component.spec.tsx
+++ b/tests/dashboard-horizons.component.spec.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import DashboardHorizons from '@/components/dashboard/DashboardHorizons';
+import type { HorizonFile, HorizonRelationship } from '@/hooks/useHorizonsRelationships';
+
+const buildHorizonFile = (overrides: Partial<HorizonFile> = {}): HorizonFile => ({
+  id: '/space/Goals/Quarter Goal.md',
+  name: 'Quarter Goal.md',
+  path: '/space/Goals/Quarter Goal.md',
+  size: 0,
+  last_modified: Math.floor(Date.parse('2026-03-31T08:00:00.000Z') / 1000),
+  extension: 'md',
+  horizonLevel: 'Goals',
+  linkedTo: [],
+  linkedFrom: [],
+  content: 'Sample horizon content',
+  createdDateTime: '2026-03-20T08:00:00.000Z',
+  ...overrides,
+});
+
+const purpose = buildHorizonFile({
+  id: '/space/Purpose & Principles/Purpose.md',
+  name: 'Purpose.md',
+  path: '/space/Purpose & Principles/Purpose.md',
+  horizonLevel: 'Purpose & Principles',
+});
+
+const goal = buildHorizonFile({
+  name: 'Quarter Goal.md',
+  path: '/space/Goals/Quarter Goal.md',
+  linkedTo: [purpose.path],
+  linkedFrom: ['/space/Projects/Alpha/README.md'],
+});
+
+const goalSibling = buildHorizonFile({
+  id: '/space/Goals/Secondary Goal.md',
+  name: 'Secondary Goal.md',
+  path: '/space/Goals/Secondary Goal.md',
+  linkedFrom: ['/space/Projects/Alpha/README.md'],
+});
+
+const project = buildHorizonFile({
+  id: '/space/Projects/Alpha/README.md',
+  name: 'Alpha',
+  path: '/space/Projects/Alpha/README.md',
+  horizonLevel: 'Projects',
+  linkedTo: [goal.path, goalSibling.path],
+  status: 'in-progress',
+});
+
+const relationships: HorizonRelationship[] = [
+  {
+    from: project.path,
+    to: goal.path,
+    fromLevel: 'Projects',
+    toLevel: 'Goals',
+    fromName: 'Alpha',
+    toName: 'Quarter Goal',
+  },
+  {
+    from: project.path,
+    to: goalSibling.path,
+    fromLevel: 'Projects',
+    toLevel: 'Goals',
+    fromName: 'Alpha',
+    toName: 'Secondary Goal',
+  },
+  {
+    from: goal.path,
+    to: purpose.path,
+    fromLevel: 'Goals',
+    toLevel: 'Purpose & Principles',
+    fromName: 'Quarter Goal',
+    toName: 'Purpose',
+  },
+];
+
+const graph = {
+  nodes: [
+    { id: purpose.path, label: 'Purpose', level: 'Purpose & Principles', group: 0 },
+    { id: goal.path, label: 'Quarter Goal', level: 'Goals', group: 2 },
+    { id: goalSibling.path, label: 'Secondary Goal', level: 'Goals', group: 2 },
+    { id: project.path, label: 'Alpha', level: 'Projects', group: 4 },
+  ],
+  edges: relationships.map((relationship) => ({
+    from: relationship.from,
+    to: relationship.to,
+  })),
+};
+
+describe('DashboardHorizons', () => {
+  it('renders the relationship map, opens a node, and shows inspector relationships', () => {
+    const onSelectFile = vi.fn();
+    const findRelated = vi.fn((filePath: string) => {
+      if (filePath === goal.path) {
+        return {
+          parents: [project],
+          children: [purpose],
+          siblings: [goalSibling],
+        };
+      }
+      return { parents: [], children: [], siblings: [] };
+    });
+
+    render(
+      <DashboardHorizons
+        horizonFiles={{
+          'Purpose & Principles': [purpose],
+          'Vision': [],
+          'Goals': [goal, goalSibling],
+          'Areas of Focus': [],
+          'Projects': [project],
+        }}
+        projects={[]}
+        relationships={relationships}
+        graph={graph}
+        findRelated={findRelated}
+        onSelectFile={onSelectFile}
+      />
+    );
+
+    expect(screen.getByLabelText('Horizon relationship map')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Quarter Goal' }));
+
+    expect(onSelectFile).toHaveBeenCalledWith(expect.objectContaining({ path: goal.path }));
+    expect(findRelated).toHaveBeenCalledWith(goal.path);
+    expect(screen.getByText('Parents')).toBeInTheDocument();
+    expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Secondary Goal').length).toBeGreaterThan(0);
+  });
+
+  it('shows a filtered empty state when search removes all linked matches', () => {
+    render(
+      <DashboardHorizons
+        horizonFiles={{
+          'Purpose & Principles': [purpose],
+          'Vision': [],
+          'Goals': [goal],
+          'Areas of Focus': [],
+          'Projects': [project],
+        }}
+        projects={[]}
+        relationships={relationships}
+        graph={graph}
+        findRelated={vi.fn(() => ({ parents: [], children: [], siblings: [] }))}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search across all horizons...'), {
+      target: { value: 'missing-node' },
+    });
+
+    expect(screen.getByText('No relationships match the current filters')).toBeInTheDocument();
+  });
+
+  it('shows a workspace empty state when no horizon relationships exist', () => {
+    render(
+      <DashboardHorizons
+        horizonFiles={{
+          'Purpose & Principles': [purpose],
+          'Vision': [],
+          'Goals': [goal],
+          'Areas of Focus': [],
+          'Projects': [],
+        }}
+        projects={[]}
+        relationships={[]}
+        graph={{ nodes: [], edges: [] }}
+        findRelated={vi.fn(() => ({ parents: [], children: [], siblings: [] }))}
+      />
+    );
+
+    expect(screen.getByText('No horizon relationships yet')).toBeInTheDocument();
+  });
+});

--- a/tests/dashboard-overview.component.spec.tsx
+++ b/tests/dashboard-overview.component.spec.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
+import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import DashboardOverview from '@/components/dashboard/DashboardOverview';
 import type { HabitWithHistory } from '@/hooks/useHabitsHistory';
 import type { GTDSpace } from '@/types';
+import type { DashboardActivityItem } from '@/utils/dashboard-activity';
 
 const buildHabit = (overrides: Partial<HabitWithHistory> = {}): HabitWithHistory => ({
   name: 'Default Habit',
@@ -29,12 +31,45 @@ const buildHabit = (overrides: Partial<HabitWithHistory> = {}): HabitWithHistory
   ...overrides,
 });
 
-describe('DashboardOverview habits stat', () => {
-  const gtdSpace: GTDSpace = {
-    root_path: '/space',
-    is_initialized: true,
-  };
+const gtdSpace: GTDSpace = {
+  root_path: '/space',
+  is_initialized: true,
+};
 
+const buildRecentActivity = (overrides: Partial<DashboardActivityItem> = {}): DashboardActivityItem => ({
+  id: 'project:/space/Projects/Alpha',
+  entityType: 'project',
+  activityType: 'updated',
+  title: 'Alpha',
+  path: '/space/Projects/Alpha',
+  timestamp: '2026-03-31T09:00:00.000Z',
+  context: 'Project',
+  ...overrides,
+});
+
+function renderOverview(
+  overrides: Partial<React.ComponentProps<typeof DashboardOverview>> = {}
+) {
+  return render(
+    <DashboardOverview
+      gtdSpace={gtdSpace}
+      projects={[]}
+      habits={[]}
+      actions={[]}
+      actionSummary={{
+        total: 0,
+        inProgress: 0,
+        completed: 0,
+        waiting: 0,
+      }}
+      horizonCounts={{}}
+      recentActivity={[]}
+      {...overrides}
+    />
+  );
+}
+
+describe('DashboardOverview', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-31T12:00:00'));
@@ -45,27 +80,15 @@ describe('DashboardOverview habits stat', () => {
   });
 
   it('shows today completion progress instead of an unrelated success-rate label', () => {
-    render(
-      <DashboardOverview
-        gtdSpace={gtdSpace}
-        projects={[]}
-        habits={[
-          buildHabit({ name: 'Habit 1', status: 'completed' }),
-          buildHabit({ name: 'Habit 2', status: 'completed', path: '/space/Habits/2.md' }),
-          buildHabit({ name: 'Habit 3', status: 'completed', path: '/space/Habits/3.md' }),
-          buildHabit({ name: 'Habit 4', status: 'completed', path: '/space/Habits/4.md' }),
-          buildHabit({ name: 'Habit 5', status: 'todo', path: '/space/Habits/5.md' }),
-        ]}
-        actions={[]}
-        actionSummary={{
-          total: 0,
-          inProgress: 0,
-          completed: 0,
-          waiting: 0,
-        }}
-        horizonCounts={{}}
-      />
-    );
+    renderOverview({
+      habits: [
+        buildHabit({ name: 'Habit 1', status: 'completed' }),
+        buildHabit({ name: 'Habit 2', status: 'completed', path: '/space/Habits/2.md' }),
+        buildHabit({ name: 'Habit 3', status: 'completed', path: '/space/Habits/3.md' }),
+        buildHabit({ name: 'Habit 4', status: 'completed', path: '/space/Habits/4.md' }),
+        buildHabit({ name: 'Habit 5', status: 'todo', path: '/space/Habits/5.md' }),
+      ],
+    });
 
     expect(screen.getByText("Today's Habits")).toBeInTheDocument();
     expect(screen.getByText('4/5')).toBeInTheDocument();
@@ -87,21 +110,7 @@ describe('DashboardOverview habits stat', () => {
       }),
     ];
 
-    const { rerender } = render(
-      <DashboardOverview
-        gtdSpace={gtdSpace}
-        projects={[]}
-        habits={habits}
-        actions={[]}
-        actionSummary={{
-          total: 0,
-          inProgress: 0,
-          completed: 0,
-          waiting: 0,
-        }}
-        horizonCounts={{}}
-      />
-    );
+    const { rerender } = renderOverview({ habits });
 
     expect(screen.getByText('1/2')).toBeInTheDocument();
     expect(screen.getByText('50% completed today')).toBeInTheDocument();
@@ -120,6 +129,7 @@ describe('DashboardOverview habits stat', () => {
           waiting: 0,
         }}
         horizonCounts={{}}
+        recentActivity={[]}
       />
     );
 
@@ -128,37 +138,76 @@ describe('DashboardOverview habits stat', () => {
   });
 
   it('counts today completions from period history even when analytics history excludes reset rows', () => {
-    render(
-      <DashboardOverview
-        gtdSpace={gtdSpace}
-        projects={[]}
-        habits={[
-          buildHabit({
-            name: 'Reset-derived Habit',
-            status: 'todo',
-            history: [],
-            periodHistory: [{ date: '2026-03-31', time: '12:00 AM', completed: true, action: 'Manual' }],
-          }),
-          buildHabit({
-            name: 'Pending Habit',
-            path: '/space/Habits/2.md',
-            status: 'todo',
-            history: [],
-            periodHistory: [{ date: '2026-03-31', time: '12:00 AM', completed: false, action: 'Auto-Reset' }],
-          }),
-        ]}
-        actions={[]}
-        actionSummary={{
-          total: 0,
-          inProgress: 0,
-          completed: 0,
-          waiting: 0,
-        }}
-        horizonCounts={{}}
-      />
-    );
+    renderOverview({
+      habits: [
+        buildHabit({
+          name: 'Reset-derived Habit',
+          status: 'todo',
+          history: [],
+          periodHistory: [{ date: '2026-03-31', time: '12:00 AM', completed: true, action: 'Manual' }],
+        }),
+        buildHabit({
+          name: 'Pending Habit',
+          path: '/space/Habits/2.md',
+          status: 'todo',
+          history: [],
+          periodHistory: [{ date: '2026-03-31', time: '12:00 AM', completed: false, action: 'Auto-Reset' }],
+        }),
+      ],
+    });
 
     expect(screen.getByText('1/2')).toBeInTheDocument();
     expect(screen.getByText('50% completed today')).toBeInTheDocument();
+  });
+
+  it('renders recent activity rows and forwards clicks', () => {
+    const onSelectActivity = vi.fn();
+
+    renderOverview({
+      recentActivity: [
+        buildRecentActivity(),
+        buildRecentActivity({
+          id: 'habit:/space/Habits/stretch.md',
+          entityType: 'habit',
+          activityType: 'completed',
+          title: 'Stretch',
+          path: '/space/Habits/stretch.md',
+          timestamp: '2026-03-31T10:00:00.000Z',
+          context: 'Habit',
+        }),
+      ],
+      onSelectActivity,
+    });
+
+    expect(screen.getByText('Recent Activity')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Stretch'));
+
+    expect(onSelectActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'habit:/space/Habits/stretch.md',
+        entityType: 'habit',
+        activityType: 'completed',
+      })
+    );
+  });
+
+  it('shows only core GTD horizons and forwards horizon clicks', () => {
+    const onSelectHorizon = vi.fn();
+
+    renderOverview({
+      horizonCounts: {
+        'Someday Maybe': 7,
+        'Goals': 2,
+        'Areas of Focus': 4,
+        'Purpose & Principles': 1,
+      },
+      onSelectHorizon,
+    });
+
+    expect(screen.queryByText('Someday Maybe')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Goals'));
+
+    expect(onSelectHorizon).toHaveBeenCalledWith('Goals');
   });
 });

--- a/tests/gtd-dashboard.component.spec.tsx
+++ b/tests/gtd-dashboard.component.spec.tsx
@@ -1,11 +1,65 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import GTDDashboard from '@/components/gtd/GTDDashboard';
 import { emitContentSaved, emitMetadataChange } from '@/utils/content-event-bus';
 
 const mocks = vi.hoisted(() => ({
+  action: {
+    id: '/mock/workspace/Projects/Alpha/Actions/review.md',
+    name: 'Review launch plan',
+    path: '/mock/workspace/Projects/Alpha/Actions/review.md',
+    projectName: 'Alpha',
+    projectPath: '/mock/workspace/Projects/Alpha',
+    status: 'todo',
+    createdDate: '2026-03-30T08:00:00.000Z',
+    modifiedDate: '2026-03-31T08:00:00.000Z',
+  },
+  project: {
+    id: '/mock/workspace/Projects/Alpha',
+    name: 'Alpha',
+    path: '/mock/workspace/Projects/Alpha',
+    status: 'in-progress',
+    description: 'Alpha project',
+    createdDateTime: '2026-03-28T08:00:00.000Z',
+    modifiedDate: '2026-03-31T07:00:00.000Z',
+    completionPercentage: 40,
+  },
+  habit: {
+    name: 'Stretch',
+    frequency: 'daily',
+    status: 'todo',
+    path: '/mock/workspace/Habits/stretch.md',
+    createdDateTime: '2026-03-25T08:00:00.000Z',
+    last_updated: '2026-03-31T06:00:00.000Z',
+    history: [],
+    periodHistory: [],
+    currentStreak: 0,
+    bestStreak: 0,
+    averageStreak: 0,
+    successRate: 0,
+    totalCompletions: 0,
+    totalAttempts: 0,
+    recentTrend: 'stable',
+    linkedProjects: [],
+    linkedAreas: [],
+    linkedGoals: [],
+    linkedVision: [],
+    linkedPurpose: [],
+  },
+  goal: {
+    id: '/mock/workspace/Goals/North Star.md',
+    name: 'North Star.md',
+    path: '/mock/workspace/Goals/North Star.md',
+    size: 0,
+    last_modified: Math.floor(Date.parse('2026-03-30T08:00:00.000Z') / 1000),
+    extension: 'md',
+    horizonLevel: 'Goals',
+    linkedTo: [],
+    linkedFrom: [],
+    createdDateTime: '2026-03-29T08:00:00.000Z',
+  },
   loadProjects: vi.fn(async () => []),
   loadProjectsData: vi.fn(async () => []),
   loadHabits: vi.fn(async () => undefined),
@@ -15,8 +69,14 @@ const mocks = vi.hoisted(() => ({
   updateActionStatus: vi.fn(async () => undefined),
   updateProject: vi.fn(async () => undefined),
   loadHorizons: vi.fn(async () => undefined),
-  withErrorHandling: vi.fn(async <T,>(operation: () => Promise<T>) => operation()),
   toast: vi.fn(),
+  safeInvoke: vi.fn(),
+  findRelated: vi.fn(() => ({ parents: [], children: [], siblings: [] })),
+  lastOverviewProps: null as any,
+  lastHabitsProps: null as any,
+  lastHorizonsProps: null as any,
+  lastCreateHabitDialogProps: null as any,
+  lastCreatePageDialogProps: null as any,
 }));
 
 vi.mock('@/hooks/useGTDSpace', () => ({
@@ -28,13 +88,16 @@ vi.mock('@/hooks/useGTDSpace', () => ({
 
 vi.mock('@/hooks/useActionsData', () => ({
   useActionsData: () => ({
-    actions: [],
+    actions: [mocks.action],
     isLoading: false,
     summary: {
-      total: 0,
-      inProgress: 0,
+      total: 1,
+      inProgress: 1,
       completed: 0,
       waiting: 0,
+      overdue: 0,
+      dueToday: 0,
+      dueThisWeek: 1,
     },
     loadActions: mocks.loadActions,
     updateActionStatus: mocks.updateActionStatus,
@@ -43,7 +106,7 @@ vi.mock('@/hooks/useActionsData', () => ({
 
 vi.mock('@/hooks/useProjectsData', () => ({
   useProjectsData: () => ({
-    projects: [],
+    projects: [mocks.project],
     isLoading: false,
     loadProjects: mocks.loadProjectsData,
     updateProject: mocks.updateProject,
@@ -52,10 +115,10 @@ vi.mock('@/hooks/useProjectsData', () => ({
 
 vi.mock('@/hooks/useHabitsHistory', () => ({
   useHabitsHistory: () => ({
-    habits: [],
+    habits: [mocks.habit],
     isLoading: false,
     summary: {
-      total: 0,
+      total: 1,
       completedToday: 0,
       streaksActive: 0,
       averageSuccessRate: 0,
@@ -70,17 +133,20 @@ vi.mock('@/hooks/useHabitsHistory', () => ({
 
 vi.mock('@/hooks/useHorizonsRelationships', () => ({
   useHorizonsRelationships: () => ({
-    horizons: {},
-    relationships: {},
+    horizons: {
+      Goals: {
+        name: 'Goals',
+        altitude: '30,000 ft',
+        files: [mocks.goal],
+        linkedCount: 0,
+        unlinkedCount: 1,
+      },
+    },
+    relationships: [],
+    graph: { nodes: [], edges: [] },
     isLoading: false,
     loadHorizons: mocks.loadHorizons,
-    findRelated: vi.fn(),
-  }),
-}));
-
-vi.mock('@/hooks/useErrorHandler', () => ({
-  useErrorHandler: () => ({
-    withErrorHandling: mocks.withErrorHandling,
+    findRelated: mocks.findRelated,
   }),
 }));
 
@@ -103,24 +169,66 @@ vi.mock('@/components/ui/tabs', () => ({
 }));
 
 vi.mock('@/components/dashboard', () => ({
-  DashboardOverview: () => <div data-testid="dashboard-overview" />,
+  DashboardOverview: (props: any) => {
+    mocks.lastOverviewProps = props;
+    return (
+      <div data-testid="dashboard-overview">
+        <button type="button" onClick={() => props.onSelectHorizon?.('Goals')}>Jump Goals</button>
+        <button type="button" onClick={() => props.onSelectActivity?.(props.recentActivity[0])}>Open Activity</button>
+        <button type="button" onClick={() => props.onSelectProject?.('/mock/workspace/Projects/Alpha')}>Open Project</button>
+        <div data-testid="recent-activity-count">{props.recentActivity.length}</div>
+      </div>
+    );
+  },
   DashboardActions: () => <div data-testid="dashboard-actions" />,
   DashboardProjects: () => <div data-testid="dashboard-projects" />,
-  DashboardHabits: () => <div data-testid="dashboard-habits" />,
-  DashboardHorizons: () => <div data-testid="dashboard-horizons" />,
+  DashboardHabits: (props: any) => {
+    mocks.lastHabitsProps = props;
+    return (
+      <div data-testid="dashboard-habits">
+        <button type="button" onClick={() => props.onCreateHabit?.()}>Create Habit</button>
+      </div>
+    );
+  },
+  DashboardHorizons: (props: any) => {
+    mocks.lastHorizonsProps = props;
+    return (
+      <div data-testid="dashboard-horizons">
+        <div>Selected level: {props.selectedLevel}</div>
+        <button type="button" onClick={() => props.onCreateFile?.('Goals')}>Create Goal</button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('@/components/gtd', () => ({
   GTDProjectDialog: () => null,
   GTDActionDialog: () => null,
+  CreateHabitDialog: (props: any) => {
+    mocks.lastCreateHabitDialogProps = props;
+    if (!props.isOpen) return null;
+    return (
+      <button type="button" onClick={() => props.onSuccess?.('/mock/workspace/Habits/New Habit.md')}>
+        Confirm Habit
+      </button>
+    );
+  },
+  CreatePageDialog: (props: any) => {
+    mocks.lastCreatePageDialogProps = props;
+    if (!props.isOpen) return null;
+    return (
+      <div>
+        <div data-testid="page-section">{props.sectionId}</div>
+        <button type="button" onClick={() => props.onSuccess?.('/mock/workspace/Goals/New Goal.md')}>
+          Confirm Page
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('@/utils/safe-invoke', () => ({
-  safeInvoke: vi.fn(),
-}));
-
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
+  safeInvoke: (...args: unknown[]) => mocks.safeInvoke(...args),
 }));
 
 vi.mock('@/utils/logger', () => ({
@@ -132,10 +240,16 @@ vi.mock('@/utils/logger', () => ({
   }),
 }));
 
-describe('GTDDashboard habit refresh subscriptions', () => {
+describe('GTDDashboard', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    mocks.safeInvoke.mockImplementation(async (command: string) => {
+      if (command === 'check_file_exists') {
+        return true;
+      }
+      return null;
+    });
   });
 
   afterEach(() => {
@@ -143,8 +257,11 @@ describe('GTDDashboard habit refresh subscriptions', () => {
     vi.useRealTimers();
   });
 
-  function renderDashboard() {
-    return render(
+  function renderDashboard(overrides: Partial<React.ComponentProps<typeof GTDDashboard>> = {}) {
+    const onSelectProject = vi.fn();
+    const onSelectFile = vi.fn();
+
+    render(
       <GTDDashboard
         currentFolder="/mock/workspace"
         gtdSpace={{
@@ -152,10 +269,13 @@ describe('GTDDashboard habit refresh subscriptions', () => {
           isGTDSpace: true,
           projects: [],
         } as any}
-        onSelectProject={vi.fn()}
-        onSelectFile={vi.fn()}
+        onSelectProject={onSelectProject}
+        onSelectFile={onSelectFile}
+        {...overrides}
       />
     );
+
+    return { onSelectProject, onSelectFile };
   }
 
   it('refreshes habits when a habit file is saved through the content event bus', async () => {
@@ -230,5 +350,100 @@ describe('GTDDashboard habit refresh subscriptions', () => {
     });
 
     expect(mocks.refreshHabits).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the canonical habit dialog and reloads habits plus the created file on success', async () => {
+    const { onSelectFile } = renderDashboard();
+
+    mocks.loadHabits.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Habit' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole('button', { name: 'Confirm Habit' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Habit' }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.loadHabits).toHaveBeenCalledWith('/mock/workspace');
+    expect(onSelectFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/mock/workspace/Habits/New Habit.md',
+        name: 'New Habit.md',
+      })
+    );
+  });
+
+  it('opens the canonical page dialog for goals and reloads horizons plus the created file on success', async () => {
+    const { onSelectFile } = renderDashboard();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Goal' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('page-section')).toHaveTextContent('goals');
+
+    mocks.loadHorizons.mockClear();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Page' }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.loadHorizons).toHaveBeenCalledWith('/mock/workspace', []);
+    expect(onSelectFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/mock/workspace/Goals/New Goal.md',
+        name: 'New Goal.md',
+      })
+    );
+  });
+
+  it('deep-links Overview horizon selection into the Horizons tab state and computes recent activity', async () => {
+    renderDashboard();
+
+    expect(screen.getByTestId('recent-activity-count')).toHaveTextContent('4');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Jump Goals' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Selected level: Goals')).toBeInTheDocument();
+    expect(mocks.lastHorizonsProps.selectedLevel).toBe('Goals');
+  });
+
+  it('uses shared open helpers for activity rows and project readmes', async () => {
+    const { onSelectProject, onSelectFile } = renderDashboard();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open Activity' }));
+      await Promise.resolve();
+    });
+
+    expect(onSelectFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: mocks.action.path,
+        name: 'review.md',
+      })
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open Project' }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onSelectProject).toHaveBeenCalledWith('/mock/workspace/Projects/Alpha');
+    expect(onSelectFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/mock/workspace/Projects/Alpha/README.md',
+        name: 'README.md',
+      })
+    );
   });
 });

--- a/tests/upcoming-deadlines-card.component.spec.tsx
+++ b/tests/upcoming-deadlines-card.component.spec.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import UpcomingDeadlinesCard from '@/components/dashboard/UpcomingDeadlinesCard';
+import type { ActionItem } from '@/hooks/useActionsData';
+import type { ProjectWithMetadata } from '@/hooks/useProjectsData';
+
+const buildProject = (overrides: Partial<ProjectWithMetadata> = {}): ProjectWithMetadata => ({
+  id: '/space/Projects/Alpha',
+  name: 'Launch Alpha',
+  path: '/space/Projects/Alpha',
+  status: 'in-progress',
+  completionPercentage: 65,
+  dueDate: '2026-04-04',
+  createdDateTime: '2026-03-01T09:00:00.000Z',
+  ...overrides,
+} as ProjectWithMetadata);
+
+const buildAction = (overrides: Partial<ActionItem> = {}): ActionItem => ({
+  id: '/space/Projects/Alpha/Actions/release.md',
+  name: 'Release lesson 6',
+  path: '/space/Projects/Alpha/Actions/release.md',
+  projectName: 'Alpha',
+  projectPath: '/space/Projects/Alpha',
+  status: 'todo',
+  dueDate: '2026-04-05',
+  ...overrides,
+});
+
+describe('UpcomingDeadlinesCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-31T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the refactored toolbar, project progress, and click handlers', () => {
+    const onSelectProject = vi.fn();
+    const onSelectAction = vi.fn();
+
+    render(
+      <UpcomingDeadlinesCard
+        projects={[buildProject()]}
+        actions={[buildAction()]}
+        onSelectProject={onSelectProject}
+        onSelectAction={onSelectAction}
+      />
+    );
+
+    expect(screen.getByText('Upcoming Deadlines')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Only overdue' })).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Include actions' })).toBeInTheDocument();
+    expect(screen.getByText('Project progress')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Launch Alpha'));
+    fireEvent.click(screen.getByText('Release lesson 6'));
+
+    expect(onSelectProject).toHaveBeenCalledWith('/space/Projects/Alpha');
+    expect(onSelectAction).toHaveBeenCalledWith('/space/Projects/Alpha/Actions/release.md');
+  });
+
+  it('toggles actions and overdue filtering with stable empty states', () => {
+    render(
+      <UpcomingDeadlinesCard
+        projects={[
+          buildProject({
+            name: 'Overdue Project',
+            path: '/space/Projects/Overdue',
+            dueDate: '2026-03-28',
+          }),
+        ]}
+        actions={[
+          buildAction({
+            name: 'Future Action',
+            path: '/space/Projects/Alpha/Actions/future.md',
+            dueDate: '2026-04-06',
+          }),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Include actions' }));
+    expect(screen.queryByText('Future Action')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Only overdue' }));
+    expect(screen.getByText('Overdue')).toBeInTheDocument();
+    expect(screen.getByText('Overdue Project')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Only overdue' }));
+    expect(screen.getByText('No upcoming deadlines this week')).toBeInTheDocument();
+  });
+
+  it('shows empty states for no overdue items and no upcoming deadlines', () => {
+    const { rerender } = render(
+      <UpcomingDeadlinesCard
+        projects={[]}
+        actions={[]}
+      />
+    );
+
+    expect(screen.getByText('No upcoming deadlines this week')).toBeInTheDocument();
+
+    rerender(
+      <UpcomingDeadlinesCard
+        projects={[
+          buildProject({
+            name: 'Soon Project',
+            path: '/space/Projects/Soon',
+            dueDate: '2026-04-06',
+          }),
+        ]}
+        actions={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Only overdue' }));
+    expect(screen.getByText('No overdue items')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Reworked the GTD dashboard overview to surface a recent activity feed and extracted upcoming deadlines into a dedicated card.
- Expanded the horizons experience with a real relationship map, richer selection state, and tighter filtering/search behavior.
- Added dashboard activity utilities and substantially expanded component coverage for overview, horizons, habits, deadlines, and dashboard flows.
- Updated repo guidance and refreshed MCP-related Rust dependency locks.

## Testing
- `npx vitest run tests/dashboard-activity.spec.ts tests/dashboard-habits.component.spec.tsx tests/dashboard-horizons.component.spec.tsx tests/dashboard-overview.component.spec.tsx tests/gtd-dashboard.component.spec.tsx tests/upcoming-deadlines-card.component.spec.tsx`
- Not run: `npm run type-check`
- Not run: `npm run lint`
- Not run: `cd src-tauri && cargo fmt --check && cargo clippy -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive horizon relationship map with inspector, node selection, and level-aware filtering.
  * Upcoming Deadlines card with overdue/7-day toggle, include-actions switch, clickable rows, and progress indicators.
  * Recent Activity feed on the dashboard aggregating actions, projects, habits, and horizons (sorted, limited).
  * Habit frequency display added for "Every 5 Minutes".

* **Documentation**
  * Added "Engineering Principles" guidelines.

* **Tests**
  * New/expanded suites for horizons, habits, overview, deadlines, activity feed, and dashboard flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->