### PR TITLE
docs: add v2.7.0 release notes

### DIFF
--- a/docs/releases/v2.7.0.md
+++ b/docs/releases/v2.7.0.md
@@ -1,0 +1,28 @@
+# GTD Space {{tag}}
+
+## Highlights
+
+- Added a real dashboard recent-activity feed, a linked horizons relationship map, and cleaner deep-linking between the Overview and Horizons views.
+- Replaced dashboard quick-create prompts with the app's canonical dialogs and refactored the Upcoming Deadlines card so it fits the dashboard column cleanly.
+
+## Notable Changes
+
+- Overview now shows recent activity across projects, actions, habits, and higher-horizon files instead of a placeholder panel, and those rows open the underlying item directly.
+- Horizons now includes an SVG relationship map with search-aware filtering, linked-only behavior, node inspection, keyboard activation, and better path normalization for graph lookups.
+- Dashboard create flows for habits and horizon files now use the existing structured dialogs, and habit cadence rendering now correctly covers the `5-minute` frequency.
+- Project README resolution and horizon/project timestamp handling were tightened so dashboard recency and relationship data reflect the real project-root README metadata instead of nested files or synthetic update times.
+- The Upcoming Deadlines card was split into a dedicated component with a more stable header, tighter footer, and row layout that avoids badge and control collisions at dashboard widths.
+
+## Installation
+
+Download the installer or package that matches your platform:
+
+- Windows: `.msi` installer or `.exe` (NSIS) installer
+- macOS Intel: `.dmg` for Intel Macs
+- macOS Apple Silicon: `.dmg` for Apple Silicon Macs
+- Linux: `.AppImage` (universal) or `.deb` (Debian/Ubuntu)
+
+## Notes
+
+- `{{tag}}` is the recommended minor upgrade on top of `v2.6.0`.
+- No workspace migration is required for this release.


### PR DESCRIPTION
## Summary
- add the checked-in release notes file for v2.7.0
- unblock the scripted release flow, which requires exact release notes on main before tagging

## Testing
- npm run release:notes -- v2.7.0
- cargo test --manifest-path src-tauri/Cargo.toml --bins --tests
- coderabbit review --plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v2.7.0 with highlights and notable changes across dashboard, overview, horizons, deep-linking, habit/horizon file creation, deadline cards, README resolution, and timestamp handling.
  * Minor upgrade from v2.6.0 with no workspace migration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->