### PR TITLE
chore: bump version to v2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtdspace",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gtdspace",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@blocknote/code-block": "~0.37.0",
         "@blocknote/core": "~0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gtdspace",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "GTD-first productivity system with integrated markdown editing",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtdspace"
-version = "2.6.0"
+version = "2.7.0"
 description = "GTD-first productivity system with integrated markdown editing"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/mcp-server/Cargo.lock
+++ b/src-tauri/mcp-server/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "gtdspace"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "GTD Space",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "identifier": "com.gtdspace.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump the shipped app version from 2.6.0 to 2.7.0 across the packaging surface
- keep the checked-in v2.7.0 release notes and release branch aligned
- prepare the final v2.7.0 tag push after merge to main

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml --bins --tests
- npm run release:minor -- --dry-run
- coderabbit review --plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->